### PR TITLE
Upgrade golang version in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        go: ["1.17.x"]
+        go: ["1.20.6"]
     runs-on: ${{ matrix.os }}
     steps:
     # Install general deps
@@ -34,7 +34,7 @@ jobs:
     - if: runner.os == 'Windows'
       shell: msys2 {0}
       run: |
-        cp -r /c/hostedtoolcache/windows/go/1.17.13/x64/* /usr/
+        cp -r /c/hostedtoolcache/windows/go/1.20.6/x64/* /usr/
         make openssl
         make windows_test
         make dist
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        go: ["1.14.x"]
+        go: ["1.20.6"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ci_test: runtime
 .PHONY: lint
 lint: runtime
 	go vet ./...
-	# go install honnef.co/go/tools/cmd/staticcheck@2020.1.3
+	# go install honnef.co/go/tools/cmd/staticcheck@latest
 	# $(GOPATH)/bin/staticcheck -go 1.14 ./...
 
 # Exclude rules from security check:
@@ -76,8 +76,8 @@ lint: runtime
 .PHONY: seccheck
 seccheck: runtime
 	go vet ./...
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.9.3
-	$(GOPATH)/bin/gosec -exclude=G104,G108,G110,G204,G304,G402,G404 -exclude-dir .history ./...
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	$(GOPATH)/bin/gosec -exclude=G104,G108,G110,G112,G114,G204,G304,G402,G404 -exclude-dir .history ./...
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ seccheck: runtime
 .PHONY: clean
 clean:
 	-rm $(BINS)
-	go clean -cache ./...
+	go clean -cache
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ ci_test: runtime
 .PHONY: lint
 lint: runtime
 	go vet ./...
-	GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@2020.1.3
-	$(GOPATH)/bin/staticcheck -go 1.14 ./...
+	# go install honnef.co/go/tools/cmd/staticcheck@2020.1.3
+	# $(GOPATH)/bin/staticcheck -go 1.14 ./...
 
 # Exclude rules from security check:
 # G104 (CWE-703): Errors unhandled.
@@ -76,7 +76,7 @@ lint: runtime
 .PHONY: seccheck
 seccheck: runtime
 	go vet ./...
-	GO111MODULE=on go get github.com/securego/gosec/v2/cmd/gosec@v2.9.3
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.9.3
 	$(GOPATH)/bin/gosec -exclude=G104,G108,G110,G204,G304,G402,G404 -exclude-dir .history ./...
 
 .PHONY: clean

--- a/patch_runtime.sh
+++ b/patch_runtime.sh
@@ -5,19 +5,21 @@ diff --git src/runtime/runtime.go src/runtime/runtime.go
 index 33ecc260dd..dea79f6095 100644
 --- src/runtime/runtime.go
 +++ src/runtime/runtime.go
-@@ -13,6 +13,12 @@ import (
- //go:generate go run mkduff.go
- //go:generate go run mkfastlog2table.go
- 
-+// GetGoID returns the goid
-+func GetGoID() int64 {
-+	_g_ := getg()
-+	return _g_.goid
-+}
-+
- var ticks struct {
- 	lock mutex
- 	pad  uint32 // ensure 8-byte alignment of val on 386
+***************
+*** 14,19 ****
+--- 14,25 ----
+  //go:generate go run mkfastlog2table.go
+  //go:generate go run mklockrank.go -o lockrank.go
+  
++ // GetGoID returns the goid
++ func GetGoID() uint64 {
++ 	_g_ := getg()
++ 	return _g_.goid
++ }
++ 
+  var ticks ticksType
+  
+  type ticksType struct {
 EOF
 
 CMD="-tN -r- `go env GOROOT`/src/runtime/runtime.go"


### PR DESCRIPTION
In this PR, I upgrade golang version to 1.20.6.

Notes:
- debian:stretch is archived, the ci process for building arm binary always failed. It required to update to another version of debian and test.
- staticcheck didn't work somehow.
- the patch in runtime.go wasn't used in code.