### PR TITLE
Added Support for Drive and Member Addresses and Improved Cache logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Name
 SYNOPSYS
   diode [-allowlists=] [-api=false] [-apiaddr=localho...]
         [-bind=] [-blocklists=] [-blockprofile=] [-blockprofilerate=1]
-        [-bnscachetime=10m0s] [-configpath=] [-cpuprofile=] [-dbpath=/home/t...]
+        [-resolvecachetime=10m0s] [-configpath=] [-cpuprofile=] [-dbpath=/home/t...]
         [-debug=false] [-diodeaddrs=] [-e2etimeout=15s] [-fleet=]
         [-logdatetime=false] [-logfilepath=] [-memprofile=] [-metrics=false]
         [-mutexprofile=] [-mutexprofilerate=1] [-pprofport=0] [-retrytimes=3]

--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -78,7 +78,8 @@ func init() {
 	diodeCmd.Flag.Var(&cfg.SBlocklists, "blocklists", "addresses are not allowed to connect to published resource (used when allowlists is empty)")
 	diodeCmd.Flag.Var(&cfg.SAllowlists, "allowlists", "addresses are allowed to connect to published resource (used when blocklists is empty)")
 	diodeCmd.Flag.Var(&cfg.SBinds, "bind", "bind a remote port to a local port. -bind <local_port>:<to_address>:<to_port>:(udp|tcp)")
-	diodeCmd.Flag.DurationVar(&cfg.ResolveCacheTime, "resolvecachetime", 10*time.Minute, "time for bns address resolve cache. (default: 10 minutes)")
+	diodeCmd.Flag.DurationVar(&cfg.ResolveCacheTime, "resolvecachetime", 10*time.Minute, "time for member and bns resolvers cache. (default: 10 minutes)")
+	diodeCmd.Flag.DurationVar(&cfg.ResolveCacheTime, "bnscachetime", 10*time.Minute, "(Deprecated. Please use resolvecachetime) time for bns address resolve cache. (default: 10 minutes)")
 	config.AppConfig = cfg
 	// Add diode commands
 	diodeCmd.AddSubCommand(bnsCmd)
@@ -162,6 +163,10 @@ func prepareDiode() error {
 		cfg.Binds = append(cfg.Binds, *bind)
 	}
 
+	if cfg.BnsCacheTime > 0 {
+		fmt.Println("Warning: bnscachetime is deprecated, please use resolvecachetime instead")
+		cfg.ResolveCacheTime = cfg.BnsCacheTime
+	}
 	// initialize diode application
 	app = NewDiode(cfg)
 	if err := app.Init(); err != nil {

--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -78,7 +78,7 @@ func init() {
 	diodeCmd.Flag.Var(&cfg.SBlocklists, "blocklists", "addresses are not allowed to connect to published resource (used when allowlists is empty)")
 	diodeCmd.Flag.Var(&cfg.SAllowlists, "allowlists", "addresses are allowed to connect to published resource (used when blocklists is empty)")
 	diodeCmd.Flag.Var(&cfg.SBinds, "bind", "bind a remote port to a local port. -bind <local_port>:<to_address>:<to_port>:(udp|tcp)")
-	diodeCmd.Flag.DurationVar(&cfg.BnsCacheTime, "bnscachetime", 10*time.Minute, "time for bns address resolve cache. (default: 10 minutes)")
+	diodeCmd.Flag.DurationVar(&cfg.ResolveCacheTime, "resolvecachetime", 10*time.Minute, "time for bns address resolve cache. (default: 10 minutes)")
 	config.AppConfig = cfg
 	// Add diode commands
 	diodeCmd.AddSubCommand(bnsCmd)

--- a/config/flag.go
+++ b/config/flag.go
@@ -92,6 +92,7 @@ type Config struct {
 	PrivatePublishedPorts   StringValues     `yaml:"published_private_ports,omitempty" json:"-"`
 	blocklists              map[Address]bool `yaml:"-" json:"-"`
 	ResolveCacheTime        time.Duration    `yaml:"-" json:"-"` // BNS cache time
+	BnsCacheTime            time.Duration    `yaml:"-" json:"-"` // BNS cache time
 	Allowlists              map[Address]bool `yaml:"-" json:"-"`
 	LogMode                 int              `yaml:"-" json:"-"`
 	LogDateTime             bool             `yaml:"-" json:"-"`

--- a/config/flag.go
+++ b/config/flag.go
@@ -91,7 +91,7 @@ type Config struct {
 	ProtectedPublishedPorts StringValues     `yaml:"published_protected_ports,omitempty" json:"-"`
 	PrivatePublishedPorts   StringValues     `yaml:"published_private_ports,omitempty" json:"-"`
 	blocklists              map[Address]bool `yaml:"-" json:"-"`
-	BnsCacheTime            time.Duration    `yaml:"-" json:"-"` // BNS cache time
+	ResolveCacheTime        time.Duration    `yaml:"-" json:"-"` // BNS cache time
 	Allowlists              map[Address]bool `yaml:"-" json:"-"`
 	LogMode                 int              `yaml:"-" json:"-"`
 	LogDateTime             bool             `yaml:"-" json:"-"`
@@ -243,13 +243,15 @@ type Bind struct {
 
 // Port struct for listening port
 type Port struct {
-	SrcHost      string
-	Src          int
-	To           int
-	Mode         int
-	Protocol     int
-	Allowlist    map[Address]bool
-	BnsAllowlist map[string]bool
+	SrcHost              string
+	Src                  int
+	To                   int
+	Mode                 int
+	Protocol             int
+	Allowlist            map[Address]bool
+	BnsAllowlist         map[string]bool
+	DriveAllowList       map[Address]bool
+	DriveMemberAllowList map[Address]bool
 }
 
 // ModeIdentifier returns a mode code of the human readable version

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -207,7 +207,7 @@ func (client *Client) isAllowlisted(port *config.Port, addr Address) bool {
 					if !allowed {
 						continue
 					}
-					addrs, err := client.GetCacheOrResolveMembersOfDriveMember(driveMember)
+					addrs, err := client.GetCacheOrResolveAllPeersOfAddrs(driveMember)
 					if err != nil {
 						continue
 					}
@@ -223,7 +223,7 @@ func (client *Client) isAllowlisted(port *config.Port, addr Address) bool {
 					if !allowed {
 						continue
 					}
-					addrs, err := client.GetCacheOrResolvePeersOfDrive(drive)
+					addrs, err := client.GetCacheOrResolveAllPeersOfAddrs(drive)
 					if err != nil {
 						continue
 					}

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -185,20 +185,52 @@ func (client *Client) isAllowlisted(port *config.Port, addr Address) bool {
 	case config.PrivatePublishedMode:
 		if port.Allowlist[addr] {
 			return true
-		} else if len(port.BnsAllowlist) == 0 {
-			return false
 		} else {
-			for bns, allowed := range port.BnsAllowlist {
-				if !allowed {
-					continue
+			if len(port.BnsAllowlist) != 0 {
+				for bns, allowed := range port.BnsAllowlist {
+					if !allowed {
+						continue
+					}
+					addrs, err := client.GetCacheOrResolvePeers(bns)
+					if err != nil {
+						continue
+					}
+					for _, a := range addrs {
+						if a == addr {
+							return true
+						}
+					}
 				}
-				addrs, err := client.GetCacheOrResolveBNS(bns)
-				if err != nil {
-					continue
+			}
+			if len(port.DriveMemberAllowList) != 0 {
+				for driveMember, allowed := range port.DriveMemberAllowList {
+					if !allowed {
+						continue
+					}
+					addrs, err := client.GetCacheOrResolveMembersOfDriveMember(driveMember)
+					if err != nil {
+						continue
+					}
+					for _, a := range addrs {
+						if a == addr {
+							return true
+						}
+					}
 				}
-				for _, a := range addrs {
-					if a == addr {
-						return true
+			}
+			if len(port.DriveAllowList) != 0 {
+				for drive, allowed := range port.DriveAllowList {
+					if !allowed {
+						continue
+					}
+					addrs, err := client.GetCacheOrResolvePeersOfDrive(drive)
+					if err != nil {
+						continue
+					}
+					for _, a := range addrs {
+						if a == addr {
+							return true
+						}
 					}
 				}
 			}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -924,12 +924,8 @@ func (client *Client) GetCacheOrResolvePeers(deviceName string) ([]Address, erro
 	return client.pool.GetCacheOrResolvePeers(deviceName, client)
 }
 
-func (client *Client) GetCacheOrResolvePeersOfDrive(driveAddress Address) ([]Address, error) {
-	return client.pool.GetCacheOrResolvePeersOfDrive(driveAddress, client)
-}
-
-func (client *Client) GetCacheOrResolveMembersOfDriveMember(driveMember Address) ([]Address, error) {
-	return client.pool.GetCacheOrResolveMembersOfDriveMember(driveMember, client)
+func (client *Client) GetCacheOrResolveAllPeersOfAddrs(addrs Address) ([]Address, error) {
+	return client.pool.GetCacheOrResolveAllPeersOfAddrs(addrs, client)
 }
 
 // ResolveBNS resolves the (primary) destination of the BNS entry
@@ -1077,7 +1073,7 @@ func (client *Client) ResolveMembers(members Address) (addr []Address, err error
 // driveMember are the members of the Drive contract, identified by trying to get member account value raw of the resolved members of the given address. GetAccountValueRaw returns err for the member addresses of the given address when driveMember address is given.
 // Drive are the drive contract addresses, identified by trying to get member account value raw of the resolved members of the given address. GetAccountValueRaw returns members array for the member addresses of the given address when drive address is given.
 func (client *Client) ResolveAccountType(addr Address) (string, error) {
-	client.Log().Info("Resolving Account Type: %s", addr.HexString())
+	client.Log().Info("Resolving Account Type of: %s", addr.HexString())
 
 	blockNumber, _ := client.LastValid()
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -924,6 +924,14 @@ func (client *Client) GetCacheOrResolvePeers(deviceName string) ([]Address, erro
 	return client.pool.GetCacheOrResolvePeers(deviceName, client)
 }
 
+func (client *Client) GetCacheOrResolvePeersOfDrive(driveAddress Address) ([]Address, error) {
+	return client.pool.GetCacheOrResolvePeersOfDrive(driveAddress, client)
+}
+
+func (client *Client) GetCacheOrResolveMembersOfDriveMember(driveMember Address) ([]Address, error) {
+	return client.pool.GetCacheOrResolveMembersOfDriveMember(driveMember, client)
+}
+
 // ResolveBNS resolves the (primary) destination of the BNS entry
 func (client *Client) ResolveBNS(name string) (addr []Address, err error) {
 	client.Log().Info("Resolving BNS: %s", name)
@@ -1016,6 +1024,10 @@ func (client *Client) ResolveBlockHash(blockNumber uint64) (blockHash []byte, er
 }
 
 // ResolveMembers a multisig
+// ResolveMembers resolves the members of a given address.
+// It retrieves the owner and other member addresses associated with the given address.
+// If there is no contract associated with the address, it assumes the address is a normal address.
+// It returns a slice of addresses and an error, if any.
 func (client *Client) ResolveMembers(members Address) (addr []Address, err error) {
 	client.Log().Info("Resolving Members: %s", members.HexString())
 
@@ -1058,6 +1070,34 @@ func (client *Client) ResolveMembers(members Address) (addr []Address, err error
 		}
 	}
 	return addr, nil
+}
+
+// Resolve Account type of the given address. Types are: driveMember, user or Drive
+// users are the normal addresses, identifed by trying to get member account value raw. GetAccountValueRaw returns err when user address is given.
+// driveMember are the members of the Drive contract, identified by trying to get member account value raw of the resolved members of the given address. GetAccountValueRaw returns err for the member addresses of the given address when driveMember address is given.
+// Drive are the drive contract addresses, identified by trying to get member account value raw of the resolved members of the given address. GetAccountValueRaw returns members array for the member addresses of the given address when drive address is given.
+func (client *Client) ResolveAccountType(addr Address) (string, error) {
+	client.Log().Info("Resolving Account Type: %s", addr.HexString())
+
+	blockNumber, _ := client.LastValid()
+
+	_, err := client.GetAccountValueRaw(blockNumber, addr, contract.MemberIndex())
+	if err != nil {
+		return "user", nil
+	}
+	raw, err := client.GetAccountValueRaw(blockNumber, addr, contract.MemberLocation(0))
+	if err != nil {
+		//error resolving members of the given address
+		client.Log().Error("Read invalid Member record offset: %d %v (%v)", 0, err, string(raw))
+		return "", err
+	}
+	var memberAddr util.Address
+	copy(memberAddr[:], raw[12:])
+	_, err = client.GetAccountValueRaw(blockNumber, memberAddr, contract.MemberIndex())
+	if err != nil {
+		return "driveMember", nil
+	}
+	return "drive", nil
 }
 
 // IsDeviceAllowlisted returns is given address allowlisted


### PR DESCRIPTION
- Added support for publishing to Drive Contract addresses and member addresses.
- Improved the Cache logic. Now app doesn't wait while updating the cached data.
- Changed the "BnsCacheTime" flag to "ResolveCacheTime" because now it's used for all resolvers.
- Added Address type resolving.
- Solved issue with publishing to BNS where resolver didn't resolve peers, was just resolving the device