### PR TITLE
Handle space-concatenated join contract props and multi-value control-plane configs

### DIFF
--- a/cmd/diode/join.go
+++ b/cmd/diode/join.go
@@ -329,9 +329,7 @@ func stringSliceFromValue(val interface{}) ([]string, error) {
 		fields := strings.Fields(s)
 		parts := make([]string, 0, len(fields))
 		for _, f := range fields {
-			for _, piece := range strings.Split(f, ",") {
-				parts = append(parts, piece)
-			}
+			parts = append(parts, strings.Split(f, ",")...)
 		}
 		return normalizeList(parts), nil
 	case []interface{}:


### PR DESCRIPTION
Handle space-concatenated contract props in join

join:

Treat contract public, private, and protected values as whitespace-separated publish arguments, so "22:22,0x... 21:21,0x..." behaves like -private 22:22,0x... -private 21:21,0x.... Leave the wireguard property unchanged and still consume the full string (including spaces and newlines) as a single config blob. control plane / bind-related config:

Parse string-valued properties like bind, diodeaddrs, allowlists, blockdomains, and blocklists by splitting on whitespace and commas, allowing multiple entries to be concatenated with spaces in the contract. For scalar properties socksd, debug, and fleet, only use the first token before whitespace and discard any trailing content from the contract value.