### PR TITLE
bqdowngrade fix - fixing bqfailure never counting by adding it to client manager

### DIFF
--- a/rpc/client_manager.go
+++ b/rpc/client_manager.go
@@ -30,6 +30,10 @@ type ClientManager struct {
 
 	pool   *DataPool
 	Config *config.Config
+
+	// bqFailures tracks blockquick validation failures across client recreations
+	// This persists even when clients are destroyed and recreated
+	bqFailures int
 }
 
 type nodeRequest struct {
@@ -262,6 +266,25 @@ func (cm *ClientManager) doResetBlockquickState(reason string) {
 			client.Log().Error("Blockquick downgrade failed to clear memory window: %v", err)
 		}
 	}
+}
+
+// incrementBQFailures increments and returns the blockquick failure counter
+// This counter persists across client recreations
+func (cm *ClientManager) incrementBQFailures() int {
+	var result int
+	cm.srv.Call(func() {
+		cm.bqFailures++
+		result = cm.bqFailures
+	})
+	return result
+}
+
+// resetBQFailures resets the blockquick failure counter
+// Called when validation succeeds or when reset is triggered
+func (cm *ClientManager) resetBQFailures() {
+	cm.srv.Call(func() {
+		cm.bqFailures = 0
+	})
 }
 
 func (cm *ClientManager) GetNearestClient() (client *Client) {


### PR DESCRIPTION
ref https://github.com/diodechain/diode_client/issues/187

bqdowngrade would never trigger because bqFailures was part of the client instance.  but, on a connection failure, .close is called, which terminates the instance, therebye incessantly zeroing out the accumulator.

work around here is adding bqFailures to the client manager.  this may not be ideal in the case where failures will accumulate across clients, but i think it is ok because even that should not happen.   and a successful connection to at least one client will reset the counter.