### PR TITLE
join: follow proxy_to perimeters for contract redirect

### DIFF
--- a/cmd/diode/join.go
+++ b/cmd/diode/join.go
@@ -194,7 +194,7 @@ func getPropertyValuesAt(deviceAddr util.Address, contractAddr string, keys []st
 			errs = append(errs, fmt.Sprintf("%s: failed to unpack result: %v", key, err))
 			continue
 		}
-		results[key] = value
+		results[key] = strings.TrimSpace(value)
 	}
 
 	if len(errs) > 0 {
@@ -263,23 +263,20 @@ func buildProxyToChain(deviceAddr util.Address, startContractAddr string) (chain
 
 		proxyTo := ""
 		if props != nil {
-			proxyTo = strings.TrimSpace(props["proxy_to"])
+			proxyTo = props["proxy_to"]
 		}
 		if proxyTo == "" {
-			return chain, fetchErr
-		}
-		if idx := strings.IndexAny(proxyTo, " \t\r\n"); idx >= 0 {
-			proxyTo = proxyTo[:idx]
+			return chain, nil
 		}
 		if proxyTo == "" || strings.EqualFold(proxyTo, current) {
-			return chain, fetchErr
+			return chain, nil
 		}
 
 		if !util.IsAddress([]byte(proxyTo)) {
 			if cfg != nil && cfg.Logger != nil {
 				cfg.Logger.Warn("Ignoring invalid proxy_to address '%s' on contract %s", proxyTo, current)
 			}
-			return chain, fetchErr
+			return chain, nil
 		}
 
 		key := strings.ToLower(proxyTo)
@@ -287,7 +284,7 @@ func buildProxyToChain(deviceAddr util.Address, startContractAddr string) (chain
 			if cfg != nil && cfg.Logger != nil {
 				cfg.Logger.Warn("Detected proxy_to loop at %s; stopping resolution", proxyTo)
 			}
-			return chain, fetchErr
+			return chain, nil
 		}
 		seen[key] = true
 		chain = append(chain, proxyTo)


### PR DESCRIPTION
Resolve proxy_to redirect chains during diode join contract sync so “home” perimeters can proxy devices into operating perimeters (supports nested redirects). Apply k/vs from the effective (proxied) perimeter with loop detection and max depth, and fall back to the last working perimeter when a target has no readable properties. Refactor on-chain property fetch helpers to take an explicit contract address and print the proxy chain/effective perimeter when it changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Follow proxy_to chains to select an effective perimeter (with loop detection, max depth, and fallback) and refactor contract property fetching to target explicit contracts, improving logging and trimming values.
> 
> - **Join/Contract Resolution**:
>   - Add `proxy_to` chain resolution (`buildProxyToChain`) with loop detection, address validation, and max depth, plus fallback selection (`selectContractPropsWithFallback`).
>   - `contractSync` now builds the chain, chooses the effective contract, applies its props, and prints proxy chain/effective perimeter when changed.
> - **Contract Fetching**:
>   - Refactor batch getter to `getPropertyValuesAt(deviceAddr, contractAddr, keys)` and `fetchContractPropsFromContract(...)` to fetch from an explicit contract.
>   - Trim whitespace from fetched values and enhance debug logs to include `contract` and result summaries.
> - **State/Logging**:
>   - Track `lastEffectiveContract` and `lastProxyToChain` to control output.
>   - Improved error handling and partial-result reporting during sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b3b27476438c12aca0ea6efe3a71b36550d4675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->