### PR TITLE
Remove no-tray tag from bullseye-amd64

### DIFF
--- a/.github/bullseye-amd64.dockerfile
+++ b/.github/bullseye-amd64.dockerfile
@@ -22,7 +22,6 @@ ENV GOROOT "/usr/local/go"
 RUN mkdir /go
 ENV GOPATH "/go"
 ENV PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
-ENV EXTRA_TAGS=no_tray
 
 RUN mkdir build
 WORKDIR /build


### PR DESCRIPTION
I tested it on a Bookworm server and it worked but I didn't have a Bullseye server so couldn't test it there. @dominicletz can you try that?