### PR TITLE
DoCreatePort nil pointer

### DIFF
--- a/rpc/socks.go
+++ b/rpc/socks.go
@@ -435,6 +435,14 @@ func (socksServer *Server) doConnectDevice(requestId int64, deviceName string, p
 }
 
 func doCreatePort(client *Client, deviceID Address, port int, portName string, mode string, requestId int64) (conn *ConnectedPort, err error) {
+	if client == nil {
+		err = fmt.Errorf("doCreatePort(): nil client for device %s", deviceID.HexString())
+		return
+	}
+	if client.pool == nil {
+		err = fmt.Errorf("doCreatePort(): nil datapool for device %s", deviceID.HexString())
+		return
+	}
 	// Rate limit: check if we're allowed to create another connection attempt
 	// This prevents connection storms when many attempts fail quickly
 	pool := client.pool
@@ -447,6 +455,10 @@ func doCreatePort(client *Client, deviceID Address, port int, portName string, m
 	var portOpen *edge.PortOpen
 	portOpen, err = client.PortOpen(deviceID, port, portName, mode)
 	if err != nil {
+		return
+	}
+	if portOpen == nil {
+		err = fmt.Errorf("portopen returned nil for device %s", deviceID.HexString())
 		return
 	}
 	if portOpen != nil && portOpen.Err != nil {


### PR DESCRIPTION
Add nil checks in `doCreatePort` to prevent `nil pointer dereference` panics.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf841c2f-bdaf-49cc-b4ea-055142685d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf841c2f-bdaf-49cc-b4ea-055142685d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of `doCreatePort` in `rpc/socks.go` to avoid panics and surface clearer failures.
> 
> - Guard against `nil` `client` and `client.pool` with explicit errors
> - Validate `client.PortOpen(...)` result is non-nil and handle embedded `Err`
> - Preserve existing rate limiting and connection logic; no API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f84330d77ede716f1487e8b6b9395bbf4d0967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->