### PR TITLE
Dont kill perimeter if no diode network connection

### DIFF
--- a/cmd/diode/join.go
+++ b/cmd/diode/join.go
@@ -2279,7 +2279,7 @@ func prepareWireGuardKeyOnly() error {
 // contractSync fetches contract properties once and applies them to config, ports, and wireguard
 func contractSync(cfg *config.Config) error {
 	const clientWaitTimeout = 30 * time.Second
-	client := app.WaitForFirstClient(true, clientWaitTimeout)
+	client := app.WaitForFirstClientTimeout(clientWaitTimeout)
 	if client == nil && cfg.Logger != nil {
 		cfg.Logger.Info("No relay connection after %v; continuing contract sync to allow config recovery", clientWaitTimeout)
 	}

--- a/cmd/diode/publish.go
+++ b/cmd/diode/publish.go
@@ -407,7 +407,7 @@ func publishHandler() (err error) {
 			// Restart to publish utill user send sigint to client
 			var client *rpc.Client
 			for {
-				client = app.WaitForFirstClient(true)
+				client = app.WaitForFirstClient()
 				if client != nil {
 					break
 				}


### PR DESCRIPTION
Perimeter updates were getting blocked if there was no diode network connection.  I would guess the block got put there initially because you want the network and defaults to be running before checking the perimeter the first time.  However, this created the situation where a bad perimeter config could brick the system.

Now, even if a bad perimeter bricks the network, you can recover the client and network connection by fixing the perimeter setting.