### PR TITLE
Don't use closed or closing clients

### DIFF
--- a/rpc/client_manager.go
+++ b/rpc/client_manager.go
@@ -660,9 +660,9 @@ func (cm *ClientManager) topClient(n int) *Client {
 	if n >= len(cm.topClients) {
 		return nil
 	}
-	// If the top client is nil or if it is closed, we need to refresh the top clients.
+	// If the top client is nil or if it is closed/closing, we need to refresh the top clients.
 	needRefresh := (cm.topClients[n] == nil && len(cm.clientMap) >= n) ||
-		(cm.topClients[n] != nil && cm.topClients[n].Closed())
+		(cm.topClients[n] != nil && cm.topClients[n].Closing())
 	if needRefresh {
 		cm.doSortTopClients()
 	}
@@ -679,7 +679,7 @@ func (cm *ClientManager) sortTopClients() {
 func (cm *ClientManager) doSortTopClients() {
 	onlineClients := make(ByLatency, 0, len(cm.clientMap))
 	for _, client := range cm.clientMap {
-		if client.Closed() {
+		if client.Closing() {
 			continue
 		}
 		onlineClients = append(onlineClients, client)


### PR DESCRIPTION
There was a race condition before where GetNearestClient could be called as a client/connection was shutting down, but GetNearestClient could return the closing client.  This would then create timeouts as the dead (or about to be dead) client is used but then times out.  

This PR introduces a flag "closing" that is set as soon as we know the client will be closed (reduce race window as far as possible), and then that flag is used to exclude those from GetNearestClient (and other callers of topClient and doSortTopClients).