### PR TITLE
Update openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: $(BINS)
 .PHONY: openssl
 openssl:
 	go mod download
-	bash "$(GOMODCACHE)/github.com/diodechain/openssl@v1.0.21/install_openssl.sh"
+	bash "$(GOMODCACHE)/github.com/diodechain/openssl@v1.0.22/install_openssl.sh"
 
 .PHONY: test
 test: runtime

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/diodechain/go-cache v2.1.0+incompatible
 	github.com/diodechain/go-update v2.2.11+incompatible
 	github.com/diodechain/gobert v1.0.5
-	github.com/diodechain/openssl v1.0.21
+	github.com/diodechain/openssl v1.0.22
 	github.com/diodechain/zap v0.0.0-20201117101851-06f3cd5f3263
 	github.com/dominicletz/genserver v1.3.3
 	github.com/ethereum/go-ethereum v1.13.15

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/diodechain/go-update v2.2.11+incompatible h1:SfDtOnbB6POqHHQkiUT6DA2U
 github.com/diodechain/go-update v2.2.11+incompatible/go.mod h1:CDLeFDVYEZiIq526c0grXHX1avgSUUp0sYIjWDeuxV0=
 github.com/diodechain/gobert v1.0.5 h1:8wDdUgNsABXirxV1INoRzRvr8UWrImrdnfrfy7DHn98=
 github.com/diodechain/gobert v1.0.5/go.mod h1:X9tC96925Yf6P16ii8Uo4nGdqDH7mLfxD9FDpKxEyrU=
-github.com/diodechain/openssl v1.0.21 h1:DGU6KuCujApjagVYbnM+ED5Ngg19hU+5vVxp9ZerZ/4=
-github.com/diodechain/openssl v1.0.21/go.mod h1:kfVLFzTNC5K1KAszv8nPfqjxDMyONyYzuYYT+OaBtpM=
+github.com/diodechain/openssl v1.0.22 h1:rtJmHPzBzoPEUGsA3QliCwYJXBi66wozhjgC3DvVljc=
+github.com/diodechain/openssl v1.0.22/go.mod h1:kfVLFzTNC5K1KAszv8nPfqjxDMyONyYzuYYT+OaBtpM=
 github.com/diodechain/zap v0.0.0-20201117101851-06f3cd5f3263 h1:IzzrLj8ehGjdejK48kf+/qgLLVdyMaCkq6mskuDXAAM=
 github.com/diodechain/zap v0.0.0-20201117101851-06f3cd5f3263/go.mod h1:lOf21r6wUM2B9rkJhTIeMwU56gvI956/ESIC0jCi/yM=
 github.com/dominicletz/genserver v1.3.3 h1:6s0i8U2itv+oyDk1sakuQln2j7CnTun7eEb7LPa2xPs=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency bump that primarily affects the OpenSSL install/build step; potential issues would be limited to build/runtime compatibility with the new OpenSSL version.
> 
> **Overview**
> Updates the `github.com/diodechain/openssl` dependency from `v1.0.21` to `v1.0.22` and refreshes `go.sum` accordingly.
> 
> Adjusts the `Makefile` `openssl` target to run the `v1.0.22` `install_openssl.sh` script from the module cache.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ef29f834f9a4dc53b4dde9e7459ac070441ed66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->