### PR TITLE
Add support for PostUp command in WireGuard configuration processing

### DIFF
--- a/cmd/diode/join.go
+++ b/cmd/diode/join.go
@@ -1491,7 +1491,7 @@ func processWireGuardConfig(client *rpc.Client, deviceAddr util.Address, contrac
 	switch {
 	case privLineIdx >= 0 && privAuto:
 		// TODO: Fetch device private key from contract when device-only access is enabled.
-		privB64, pubB64, err = readOrCreateWGPrivateKey(keyPath)
+		_, pubB64, err = readOrCreateWGPrivateKey(keyPath)
 		if err != nil {
 			return "", nil, "", err
 		}


### PR DESCRIPTION
This pull request updates the `processWireGuardConfig` function in `cmd/diode/join.go` to add support for a special case where the WireGuard configuration uses `PrivateKey=PostUp` as an indicator, and to validate the presence of a corresponding `PostUp` command. The changes improve configuration parsing and error handling for this scenario.

**WireGuard configuration parsing improvements:**

* Added detection and handling for `PrivateKey=PostUp` in the `[Interface]` section, including a new `privPostUp` flag to track this case. If this special value is found, the corresponding config line is removed and further processing is adjusted.
* Introduced logic to track and validate the presence and value of the `PostUp` key, ensuring that if `PrivateKey=PostUp` is used, a non-empty `PostUp` command must also be provided; otherwise, an error is returned. [[1]](diffhunk://#diff-c814ef1f79979f42b6cd69cd5cfe15c3903ecccd6e2f75f137b39f7fee3685b6R1316-R1322) [[2]](diffhunk://#diff-c814ef1f79979f42b6cd69cd5cfe15c3903ecccd6e2f75f137b39f7fee3685b6R1401-R1417) [[3]](diffhunk://#diff-c814ef1f79979f42b6cd69cd5cfe15c3903ecccd6e2f75f137b39f7fee3685b6L1460-R1488)

**Error handling enhancements:**

* Improved error reporting for missing `[Interface]` sections and for invalid combinations of `PrivateKey=PostUp` without a valid `PostUp` command.