### PR TITLE
fix(rpc): restore plain host:port support for -diodeaddrs

### DIFF
--- a/rpc/client_manager.go
+++ b/rpc/client_manager.go
@@ -226,13 +226,15 @@ func normalizeHostPort(host string) string {
 	if host == "" {
 		return ""
 	}
-	url, err := url.Parse(host)
-	if err == nil {
-		return net.JoinHostPort(url.Hostname(), url.Port())
-	}
-
 	if h, p, err := net.SplitHostPort(host); err == nil {
 		return net.JoinHostPort(strings.TrimSpace(strings.ToLower(h)), p)
+	}
+	if strings.Contains(host, "://") {
+		if u, err := url.Parse(host); err == nil {
+			if h, p := strings.TrimSpace(strings.ToLower(u.Hostname())), strings.TrimSpace(u.Port()); h != "" && p != "" {
+				return net.JoinHostPort(h, p)
+			}
+		}
 	}
 	return host
 }
@@ -242,13 +244,15 @@ func resolveRelayAddrFromClient(client *Client) (string, string) {
 		return "", ""
 	}
 	if remoteAddr, err := client.RemoteAddr(); err == nil && remoteAddr != nil {
-		url, err := url.Parse(remoteAddr.String())
-		if err == nil {
-			return net.JoinHostPort(url.Hostname(), url.Port()), url.Hostname()
-		}
-
 		if host, port, err := net.SplitHostPort(remoteAddr.String()); err == nil {
 			return net.JoinHostPort(host, port), host
+		}
+		if strings.Contains(remoteAddr.String(), "://") {
+			if u, err := url.Parse(remoteAddr.String()); err == nil {
+				if host, port := strings.TrimSpace(u.Hostname()), strings.TrimSpace(u.Port()); host != "" && port != "" {
+					return net.JoinHostPort(host, port), host
+				}
+			}
 		}
 		return remoteAddr.String(), remoteAddr.String()
 	}

--- a/rpc/client_manager_normalize_test.go
+++ b/rpc/client_manager_normalize_test.go
@@ -1,0 +1,24 @@
+package rpc
+
+import "testing"
+
+func TestNormalizeHostPortPlainHostPort(t *testing.T) {
+	got := normalizeHostPort("eu1.prenet.diode.io:41046")
+	if got != "eu1.prenet.diode.io:41046" {
+		t.Fatalf("expected plain host:port to remain unchanged, got %q", got)
+	}
+}
+
+func TestNormalizeHostPortFromDiodeURL(t *testing.T) {
+	got := normalizeHostPort("diode://0x937c492a77ae90de971986d003ffbc5f8bb2232c@eu1.prenet.diode.io:41046")
+	if got != "eu1.prenet.diode.io:41046" {
+		t.Fatalf("expected diode URL to normalize to host:port, got %q", got)
+	}
+}
+
+func TestNormalizeHostPortFromHTTPSURL(t *testing.T) {
+	got := normalizeHostPort("HTTPS://Example.COM:443")
+	if got != "example.com:443" {
+		t.Fatalf("expected HTTPS URL to normalize to lowercase host:port, got %q", got)
+	}
+}


### PR DESCRIPTION
Fix regression introduced by a07e80f where plain `host:port` values could be normalized to `:`, causing single `-diodeaddrs` connections to fail (`server=:` in logs).

- prefer `SplitHostPort` for plain `host:port` input
- only URL-parse when a scheme exists and host/port are non-empty
- apply the same guard in `resolveRelayAddrFromClient`
- add regression tests for both plain and URL address formats
- keep `ci_test.sh` on a single diodeaddr (override via `DIODE_CI_DIODEADDR`)