### PR TITLE
Pad private keys to 32 bytes if leading 0's

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -94,19 +94,15 @@ func DerToECDSA(derD []byte) (*ecdsa.PrivateKey, error) {
 	return toECDSA(privKey.PrivateKey, true)
 }
 
-// Secp256k1ScalarBytes returns priv.D as exactly 32 big-endian bytes, left-padded with zeros.
-// go-ethereum's secp256k1.Sign requires len(seckey)==32; big.Int.Bytes() strips leading zeros
-// so shorter slices are possible, although rare, for valid keys — that would return ErrInvalidKey ("invalid private key").
+// Secp256k1ScalarBytes returns priv.D as exactly 32 big-endian bytes (leading zeros as needed).
+// go-ethereum's secp256k1.Sign requires len(seckey)==32; big.Int.Bytes() strips leading zeros,
+// which would return ErrInvalidKey ("invalid private key"). FillBytes is the idiomatic fixed-width encoding.
 func Secp256k1ScalarBytes(priv *ecdsa.PrivateKey) []byte {
 	if priv == nil || priv.D == nil {
 		return nil
 	}
-	d := priv.D.Bytes()
-	if len(d) > 32 {
-		return d[len(d)-32:]
-	}
 	out := make([]byte, 32)
-	copy(out[32-len(d):], d)
+	priv.D.FillBytes(out)
 	return out
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -94,6 +94,22 @@ func DerToECDSA(derD []byte) (*ecdsa.PrivateKey, error) {
 	return toECDSA(privKey.PrivateKey, true)
 }
 
+// Secp256k1ScalarBytes returns priv.D as exactly 32 big-endian bytes, left-padded with zeros.
+// go-ethereum's secp256k1.Sign requires len(seckey)==32; big.Int.Bytes() strips leading zeros
+// so shorter slices are possible, although rare, for valid keys — that would return ErrInvalidKey ("invalid private key").
+func Secp256k1ScalarBytes(priv *ecdsa.PrivateKey) []byte {
+	if priv == nil || priv.D == nil {
+		return nil
+	}
+	d := priv.D.Bytes()
+	if len(d) > 32 {
+		return d[len(d)-32:]
+	}
+	out := make([]byte, 32)
+	copy(out[32-len(d):], d)
+	return out
+}
+
 // ToECDSA creates a private key with the given D value.
 func ToECDSA(d []byte) (*ecdsa.PrivateKey, error) {
 	return toECDSA(d, true)

--- a/edge/device_ticket.go
+++ b/edge/device_ticket.go
@@ -117,7 +117,7 @@ func (ct *DeviceTicket) Sign(privKey *ecdsa.PrivateKey) error {
 	if err != nil {
 		return err
 	}
-	sig, err := secp256k1.Sign(msgHash, privKey.D.Bytes())
+	sig, err := secp256k1.Sign(msgHash, crypto.Secp256k1ScalarBytes(privKey))
 	if err != nil {
 		return err
 	}

--- a/edge/transaction.go
+++ b/edge/transaction.go
@@ -163,7 +163,7 @@ func (tx *Transaction) Sign(privKey *ecdsa.PrivateKey) (err error) {
 	if err != nil {
 		return err
 	}
-	sig, err := secp256k1.Sign(msgHash, privKey.D.Bytes())
+	sig, err := secp256k1.Sign(msgHash, crypto.Secp256k1ScalarBytes(privKey))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR pads private keys to the full 32 bytes if the leading byte is zero (or bytes are zero).

This seems really weird to me that we haven't hit this issue before (~0.4% probability), but the fix works well on a broken private key I found that always generated, for example:

04/06/2026 18:58:29 ERROR failed to create new ticket: invalid private key server=as1.prenet.diode.io:41046

e.g. before (master/released binary):

hr@Hs-MacBook-Pro diode_client % diode -dbpath=/Users/hr/Dev/diodedb.db time 
INFO Diode Client version : v1.18.0 02 Apr 2026                       
INFO Client address       : 0xafec08b0342d9fe141cbc4e0a425983b066ead3e
INFO Fleet address        : 0x6000000000000000000000000000000000000000
INFO Network is validated, last valid block: 10716389 0x0000056214e0fa831c51f3ef6d98ecc10736cbfdad5aee20e10e6846a3ccf794
ERROR failed to create new ticket: invalid private key server=us2.prenet.diode.io:41046 
ERROR failed to create new ticket: invalid private key server=us1.prenet.diode.io:41046 
INFO Minimum Time         : Mon Apr  6 12:13:44 PDT 2026 (1775502824) 
INFO Maximum Time         : Mon Apr  6 12:38:44 PDT 2026 (1775504324) 

e.g. after - our branch:
hr@Hs-MacBook-Pro diode_client % ./diode -dbpath=/Users/hr/Dev/diodedb.db time
INFO Diode Client version : v1.18.0-1-g9899561 06 Apr 2026            
INFO Client address       : 0xafec08b0342d9fe141cbc4e0a425983b066ead3e
INFO Fleet address        : 0x6000000000000000000000000000000000000000
INFO Network is validated, last valid block: 10716392 0x000005cc474cc245eceadd1804a5a01ef059af67aabb6b5d65b49713ce32691a
INFO Minimum Time         : Mon Apr  6 12:14:21 PDT 2026 (1775502861) 
INFO Maximum Time         : Mon Apr  6 12:39:21 PDT 2026 (1775504361) 
hr@Hs-MacBook-Pro diode_client % 