### PR TITLE
rpc: keep published port lookups alive when datapool stalls

### DIFF
--- a/rpc/datapool.go
+++ b/rpc/datapool.go
@@ -6,6 +6,7 @@ package rpc
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/diodechain/diode_client/config"
@@ -20,6 +21,7 @@ type DataPool struct {
 	locks          map[string]bool
 	devices        map[string]*ConnectedPort
 	publishedPorts map[int]*config.Port
+	publishedState atomic.Value
 
 	memoryCache *cache.Cache
 	bnsCache    *cache.Cache
@@ -62,6 +64,7 @@ func NewPool() *DataPool {
 		connectionAttempts:   make(map[Address]int),
 		peerAddrToDeviceID:   make(map[string]Address),
 	}
+	pool.publishedState.Store(make(map[int]*config.Port))
 	if !config.AppConfig.LogDateTime {
 		pool.srv.DeadlockCallback = nil
 	}
@@ -491,7 +494,11 @@ func (p *DataPool) UnregisterConnectionPeer(peerAddr string) {
 }
 
 func (p *DataPool) GetPublishedPort(portnum int) (port *config.Port) {
-	p.srv.Call(func() { port = p.publishedPorts[portnum] })
+	state, _ := p.publishedState.Load().(map[int]*config.Port)
+	if state == nil {
+		return nil
+	}
+	port = state[portnum]
 	return
 }
 
@@ -506,8 +513,13 @@ func (p *DataPool) GetContext() (ctx *openssl.Ctx) {
 }
 
 func (p *DataPool) SetPublishedPorts(ports map[int]*config.Port) {
+	snapshot := make(map[int]*config.Port, len(ports))
+	for portnum, port := range ports {
+		snapshot[portnum] = port
+	}
+	p.publishedState.Store(snapshot)
 	p.srv.Cast(func() {
-		p.publishedPorts = ports
+		p.publishedPorts = snapshot
 	})
 }
 

--- a/rpc/datapool_test.go
+++ b/rpc/datapool_test.go
@@ -1,0 +1,74 @@
+package rpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/diodechain/diode_client/config"
+)
+
+// Regression: the old implementation routed GetPublishedPort() through the
+// DataPool actor and ignored Call() failures. If the actor was wedged long
+// enough to hit the deadlock timeout, the lookup returned nil and inbound
+// requests were rejected as "port was not published" even though the publish
+// map itself was unchanged.
+func TestGetPublishedPortDoesNotReturnFalseNilWhenActorIsBlocked(t *testing.T) {
+	prev := config.AppConfig
+	defer func() { config.AppConfig = prev }()
+
+	cfg := testConfig()
+	config.AppConfig = cfg
+
+	pool := NewPool()
+	pool.SetPublishedPorts(map[int]*config.Port{
+		8081: {To: 8081},
+	})
+	pool.srv.DeadlockTimeout = 10 * time.Millisecond
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = pool.srv.Call(func() {
+			close(locked)
+			<-release
+		})
+	}()
+	<-locked
+
+	done := make(chan *config.Port, 1)
+	go func() {
+		done <- pool.GetPublishedPort(8081)
+	}()
+
+	select {
+	case port := <-done:
+		if port == nil || port.To != 8081 {
+			t.Fatalf("expected published port 8081 while actor was blocked, got %#v", port)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("GetPublishedPort blocked on the actor")
+	}
+
+	close(release)
+}
+
+func TestSetPublishedPortsCopiesSnapshot(t *testing.T) {
+	prev := config.AppConfig
+	defer func() { config.AppConfig = prev }()
+
+	cfg := testConfig()
+	config.AppConfig = cfg
+
+	pool := NewPool()
+	ports := map[int]*config.Port{
+		8081: {To: 8081},
+	}
+
+	pool.SetPublishedPorts(ports)
+	delete(ports, 8081)
+
+	port := pool.GetPublishedPort(8081)
+	if port == nil || port.To != 8081 {
+		t.Fatalf("expected copied published port 8081, got %#v", port)
+	}
+}


### PR DESCRIPTION
This pull request refactors how published ports are stored and accessed in the `DataPool` to improve thread safety and reliability, especially when the actor is blocked. The main change is moving the published ports state to an `atomic.Value` for lock-free reads, ensuring that `GetPublishedPort` does not block or return incorrect results if the actor is wedged. Additionally, new tests are added to verify this behavior and to ensure the published ports map is safely copied.

**Thread safety and published ports state:**

* Introduced a new `atomic.Value` field `publishedState` in `DataPool` to hold the published ports map, enabling lock-free and reliable access from `GetPublishedPort`. (`rpc/datapool.go`) [[1]](diffhunk://#diff-32da6abd2cdac8db84fd1e5fcb78090386fc4cbbb6c294d1c6ee9e77c765c51dR9) [[2]](diffhunk://#diff-32da6abd2cdac8db84fd1e5fcb78090386fc4cbbb6c294d1c6ee9e77c765c51dR24)
* Updated `NewPool` to initialize `publishedState` with an empty map. (`rpc/datapool.go`)
* Modified `SetPublishedPorts` to copy the input map before storing it in `publishedState`, ensuring external changes do not affect the internal state. (`rpc/datapool.go`)
* Changed `GetPublishedPort` to read from `publishedState` instead of routing through the actor, avoiding actor deadlocks and false negatives. (`rpc/datapool.go`)

**Testing and reliability:**

* Added new tests in `rpc/datapool_test.go` to verify that `GetPublishedPort` returns correct results even if the actor is blocked, and to ensure that `SetPublishedPorts` creates a snapshot copy of the input map.