### PR TITLE
Add failover for one shot commands

### DIFF
--- a/cmd/diode/bns.go
+++ b/cmd/diode/bns.go
@@ -54,7 +54,10 @@ func bnsHandler() (err error) {
 		return
 	}
 	err = app.clientManager.CallWithClientFailover("bns block peak", func(client *rpc.Client) error {
-		bn, _ := client.GetBlockPeak()
+		bn, err := client.GetBlockPeak()
+		if err != nil {
+			return err
+		}
 		if bn == 0 {
 			return fmt.Errorf("not found")
 		}

--- a/cmd/diode/bns.go
+++ b/cmd/diode/bns.go
@@ -53,11 +53,15 @@ func bnsHandler() (err error) {
 	if err != nil {
 		return
 	}
-	client := app.clientManager.GetNearestClient()
-	// register bns record
-	bn, _ := client.GetBlockPeak()
-	if bn == 0 {
-		cfg.PrintError("Cannot find block peak: ", fmt.Errorf("not found"))
+	err = app.clientManager.CallWithClientFailover("bns block peak", func(client *rpc.Client) error {
+		bn, _ := client.GetBlockPeak()
+		if bn == 0 {
+			return fmt.Errorf("not found")
+		}
+		return nil
+	})
+	if err != nil {
+		cfg.PrintError("Cannot find block peak: ", err)
 		return
 	}
 
@@ -93,8 +97,11 @@ func handleLookup() (done bool, err error) {
 
 	var obnsAddr []util.Address
 	var ownerAddr util.Address
-	client := app.clientManager.GetNearestClient()
-	obnsAddr, err = client.ResolveBNS(lookupName)
+	err = app.clientManager.CallWithClientFailover("bns lookup", func(client *rpc.Client) error {
+		var e error
+		obnsAddr, e = client.ResolveBNS(lookupName)
+		return e
+	})
 	if err != nil {
 		cfg.PrintError("Lookup error: ", err)
 		return
@@ -102,7 +109,11 @@ func handleLookup() (done bool, err error) {
 	for _, addr := range obnsAddr {
 		cfg.PrintLabel("Lookup result: ", fmt.Sprintf("%s=0x%s", lookupName, addr.Hex()))
 	}
-	ownerAddr, err = client.ResolveBNSOwner(lookupName)
+	err = app.clientManager.CallWithClientFailover("bns owner", func(client *rpc.Client) error {
+		var e error
+		ownerAddr, e = client.ResolveBNSOwner(lookupName)
+		return e
+	})
 	if err != nil {
 		cfg.PrintError("Couldn't lookup owner: ", err)
 		return
@@ -121,24 +132,37 @@ func handleLookupAccount() (done bool, err error) {
 
 	var obnsAddr []util.Address
 	var ownerAddr util.Address
-	client := app.clientManager.GetNearestClient()
-	obnsAddr, err = client.ResolveBNS(lookupName)
+	err = app.clientManager.CallWithClientFailover("bns lookup", func(client *rpc.Client) error {
+		var e error
+		obnsAddr, e = client.ResolveBNS(lookupName)
+		return e
+	})
 	if err != nil {
 		cfg.PrintError("Lookup error: ", err)
 		return
 	}
 	for _, addr := range obnsAddr {
 		cfg.PrintLabel("Lookup result: ", fmt.Sprintf("%s=0x%s", lookupName, addr.Hex()))
-		lvbn, _ := client.LastValid()
-		account, err := client.GetValidAccount(lvbn, addr)
+		err = app.clientManager.CallWithClientFailover("bns account", func(client *rpc.Client) error {
+			lvbn, _ := client.LastValid()
+			account, e := client.GetValidAccount(lvbn, addr)
+			if e != nil {
+				return e
+			}
+			cfg.PrintLabel("Nonce: ", fmt.Sprintf("%d", account.Nonce))
+			cfg.PrintLabel("Code: ", util.EncodeToString(account.Code))
+			cfg.PrintLabel("Balance: ", fmt.Sprintf("%d (wei)", account.Balance))
+			return nil
+		})
 		if err != nil {
 			cfg.PrintError("Couldn't lookup the account: ", err)
 		}
-		cfg.PrintLabel("Nonce: ", fmt.Sprintf("%d", account.Nonce))
-		cfg.PrintLabel("Code: ", util.EncodeToString(account.Code))
-		cfg.PrintLabel("Balance: ", fmt.Sprintf("%d (wei)", account.Balance))
 	}
-	ownerAddr, err = client.ResolveBNSOwner(lookupName)
+	err = app.clientManager.CallWithClientFailover("bns owner", func(client *rpc.Client) error {
+		var e error
+		ownerAddr, e = client.ResolveBNSOwner(lookupName)
+		return e
+	})
 	if err != nil {
 		cfg.PrintError("Couldn't lookup owner: ", err)
 		return

--- a/cmd/diode/query.go
+++ b/cmd/diode/query.go
@@ -45,14 +45,17 @@ func queryHandler() (err error) {
 	resolverConfig := rpc.Config{}
 	resolver := rpc.NewResolver(resolverConfig, app.clientManager)
 
-	client := app.clientManager.GetNearestClient()
-	addr, err := util.DecodeAddress(cfg.QueryAddress)
-	if err == nil {
-		addrType, err := client.ResolveAccountType(addr)
-		if err != nil {
-			cfg.PrintError("Couldn't resolve account type: ", err)
-		} else {
+	addr, decErr := util.DecodeAddress(cfg.QueryAddress)
+	if decErr == nil {
+		if err = app.clientManager.CallWithClientFailover("query account type", func(client *rpc.Client) error {
+			addrType, e := client.ResolveAccountType(addr)
+			if e != nil {
+				return e
+			}
 			cfg.PrintLabel("Account Type: ", addrType)
+			return nil
+		}); err != nil {
+			cfg.PrintError("Couldn't resolve account type: ", err)
 		}
 	}
 

--- a/cmd/diode/reset.go
+++ b/cmd/diode/reset.go
@@ -192,11 +192,10 @@ func resetHandler() (err error) {
 		return err
 	}
 	cfg := config.AppConfig
-	client := app.clientManager.GetNearestClient()
-	if cfg.Experimental {
-		err = doInitExp(cfg, client)
-	} else {
-		err = doInit(cfg, client)
-	}
-	return err
+	return app.clientManager.CallWithClientFailover("reset init", func(client *rpc.Client) error {
+		if cfg.Experimental {
+			return doInitExp(cfg, client)
+		}
+		return doInit(cfg, client)
+	})
 }

--- a/cmd/diode/time.go
+++ b/cmd/diode/time.go
@@ -30,20 +30,20 @@ func timeHandler() (err error) {
 		return
 	}
 	cfg := config.AppConfig
-	client := app.clientManager.GetNearestClient()
-	blocknr, _ := client.LastValid()
-	header := client.GetBlockHeaderValid(blocknr)
-	if header.Number() == 0 {
-		err = ErrFailedToFetchHeader
-		return
-	}
+	return app.clientManager.CallWithClientFailover("diode time", func(client *rpc.Client) error {
+		blocknr, _ := client.LastValid()
+		header := client.GetBlockHeaderValid(blocknr)
+		if header.Number() == 0 {
+			return ErrFailedToFetchHeader
+		}
 
-	t0 := int(header.Timestamp())
-	t1 := t0 + (rpc.WindowSize() * averageBlockTime)
+		t0 := int(header.Timestamp())
+		t1 := t0 + (rpc.WindowSize() * averageBlockTime)
 
-	tm0 := time.Unix(int64(t0), 0)
-	tm1 := time.Unix(int64(t1), 0)
-	cfg.PrintLabel("Minimum Time", fmt.Sprintf("%s (%d)", tm0.Format(time.UnixDate), t0))
-	cfg.PrintLabel("Maximum Time", fmt.Sprintf("%s (%d)", tm1.Format(time.UnixDate), t1))
-	return
+		tm0 := time.Unix(int64(t0), 0)
+		tm1 := time.Unix(int64(t1), 0)
+		cfg.PrintLabel("Minimum Time", fmt.Sprintf("%s (%d)", tm0.Format(time.UnixDate), t0))
+		cfg.PrintLabel("Maximum Time", fmt.Sprintf("%s (%d)", tm1.Format(time.UnixDate), t1))
+		return nil
+	})
 }

--- a/cmd/diode/token.go
+++ b/cmd/diode/token.go
@@ -12,7 +12,6 @@ import (
 	"github.com/diodechain/diode_client/command"
 	"github.com/diodechain/diode_client/config"
 	"github.com/diodechain/diode_client/edge"
-	"github.com/diodechain/diode_client/rpc"
 	"github.com/diodechain/diode_client/util"
 )
 
@@ -93,42 +92,42 @@ func tokenHandler() (err error) {
 		return
 	}
 	appCfg := config.AppConfig
-	err = app.clientManager.CallWithClientFailover("token transfer", func(client *rpc.Client) error {
-		oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+	client := app.clientManager.GetNearestClient()
+	oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+	if err != nil {
+		return
+	}
+	var toAddr util.Address
+	if !util.IsAddress([]byte(tokenCfg.To)) {
+		var lookupAddrs []util.Address
+		lookupAddrs, err = client.ResolveBNS(tokenCfg.To)
 		if err != nil {
-			return err
+			return
 		}
-		var toAddr util.Address
-		if !util.IsAddress([]byte(tokenCfg.To)) {
-			var lookupAddrs []util.Address
-			lookupAddrs, err = client.ResolveBNS(tokenCfg.To)
-			if err != nil {
-				return err
-			}
-			if len(lookupAddrs) <= 0 {
-				return fmt.Errorf("that BNS was not found")
-			}
-			if len(lookupAddrs) > 1 {
-				return fmt.Errorf("that BNS name is backed by multiple addresses. Please select only one")
-			}
-			toAddr = lookupAddrs[0]
-		} else {
-			toAddr, err = util.DecodeAddress(tokenCfg.To)
-			if err != nil {
-				return err
-			}
+		if len(lookupAddrs) <= 0 {
+			err = fmt.Errorf("that BNS was not found")
+			return
 		}
-		tx := edge.NewTransaction(uint64(oaccount.Nonce), uint64(gasPriceWei), uint64(gasWei), toAddr, uint64(valWei), data, 0)
-		_, err = client.SendTransaction(tx)
+		if len(lookupAddrs) > 1 {
+			err = fmt.Errorf("that BNS name is backed by multiple addresses. Please select only one")
+			return
+		}
+		toAddr = lookupAddrs[0]
+	} else {
+		toAddr, err = util.DecodeAddress(tokenCfg.To)
 		if err != nil {
-			appCfg.PrintError("Cannot transfer DIODEs: ", err)
-			return err
+			return
 		}
-		wait(client, func() bool {
-			naccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
-			return err == nil && !bytes.Equal(naccount.StateRoot(), oaccount.StateRoot())
-		})
-		return nil
+	}
+	tx := edge.NewTransaction(uint64(oaccount.Nonce), uint64(gasPriceWei), uint64(gasWei), toAddr, uint64(valWei), data, 0)
+	_, err = client.SendTransaction(tx)
+	if err != nil {
+		appCfg.PrintError("Cannot transfer DIODEs: ", err)
+		return
+	}
+	wait(client, func() bool {
+		naccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+		return err == nil && !bytes.Equal(naccount.StateRoot(), oaccount.StateRoot())
 	})
 	return
 }
@@ -139,12 +138,11 @@ func showBalance() (err error) {
 		return
 	}
 	appCfg := config.AppConfig
-	return app.clientManager.CallWithClientFailover("token balance", func(client *rpc.Client) error {
-		oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
-		if err != nil {
-			return err
-		}
-		appCfg.PrintLabel("Your Balance", util.ToString(oaccount.Balance))
-		return nil
-	})
+	client := app.clientManager.GetNearestClient()
+	oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+	if err != nil {
+		return err
+	}
+	appCfg.PrintLabel("Your Balance", util.ToString(oaccount.Balance))
+	return nil
 }

--- a/cmd/diode/token.go
+++ b/cmd/diode/token.go
@@ -12,6 +12,7 @@ import (
 	"github.com/diodechain/diode_client/command"
 	"github.com/diodechain/diode_client/config"
 	"github.com/diodechain/diode_client/edge"
+	"github.com/diodechain/diode_client/rpc"
 	"github.com/diodechain/diode_client/util"
 )
 
@@ -92,45 +93,42 @@ func tokenHandler() (err error) {
 		return
 	}
 	appCfg := config.AppConfig
-	client := app.clientManager.GetNearestClient()
-	oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
-	if err != nil {
-		return
-	}
-	var toAddr util.Address
-	if !util.IsAddress([]byte(tokenCfg.To)) {
-		// lookup the bns name
-		var lookupAddrs []util.Address
-		lookupAddrs, err = client.ResolveBNS(tokenCfg.To)
+	err = app.clientManager.CallWithClientFailover("token transfer", func(client *rpc.Client) error {
+		oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
 		if err != nil {
-			return
+			return err
 		}
-		if len(lookupAddrs) <= 0 {
-			err = fmt.Errorf("that BNS was not found")
-			return
+		var toAddr util.Address
+		if !util.IsAddress([]byte(tokenCfg.To)) {
+			var lookupAddrs []util.Address
+			lookupAddrs, err = client.ResolveBNS(tokenCfg.To)
+			if err != nil {
+				return err
+			}
+			if len(lookupAddrs) <= 0 {
+				return fmt.Errorf("that BNS was not found")
+			}
+			if len(lookupAddrs) > 1 {
+				return fmt.Errorf("that BNS name is backed by multiple addresses. Please select only one")
+			}
+			toAddr = lookupAddrs[0]
+		} else {
+			toAddr, err = util.DecodeAddress(tokenCfg.To)
+			if err != nil {
+				return err
+			}
 		}
-		if len(lookupAddrs) > 1 {
-			err = fmt.Errorf("that BNS name is backed by multiple addresses. Please select only one")
-			return
-		}
-		toAddr = lookupAddrs[0]
-	} else {
-		toAddr, err = util.DecodeAddress(tokenCfg.To)
+		tx := edge.NewTransaction(uint64(oaccount.Nonce), uint64(gasPriceWei), uint64(gasWei), toAddr, uint64(valWei), data, 0)
+		_, err = client.SendTransaction(tx)
 		if err != nil {
-			return
+			appCfg.PrintError("Cannot transfer DIODEs: ", err)
+			return err
 		}
-	}
-	tx := edge.NewTransaction(uint64(oaccount.Nonce), uint64(gasPriceWei), uint64(gasWei), toAddr, uint64(valWei), data, 0)
-	_, err = client.SendTransaction(tx)
-	if err != nil {
-		appCfg.PrintError("Cannot transfer DIODEs: ", err)
-		return
-	}
-	wait(client, func() bool {
-		naccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
-		// Check state root in case the transaction is self transfer
-		// isSelfTx := appCfg.ClientAddr == toAddr
-		return err == nil && !bytes.Equal(naccount.StateRoot(), oaccount.StateRoot())
+		wait(client, func() bool {
+			naccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+			return err == nil && !bytes.Equal(naccount.StateRoot(), oaccount.StateRoot())
+		})
+		return nil
 	})
 	return
 }
@@ -141,11 +139,12 @@ func showBalance() (err error) {
 		return
 	}
 	appCfg := config.AppConfig
-	client := app.clientManager.GetNearestClient()
-	oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
-	if err != nil {
-		return
-	}
-	appCfg.PrintLabel("Your Balance", util.ToString(oaccount.Balance))
-	return
+	return app.clientManager.CallWithClientFailover("token balance", func(client *rpc.Client) error {
+		oaccount, err := client.GetValidAccount(0, appCfg.ClientAddr)
+		if err != nil {
+			return err
+		}
+		appCfg.PrintLabel("Your Balance", util.ToString(oaccount.Balance))
+		return nil
+	})
 }

--- a/rpc/client_manager.go
+++ b/rpc/client_manager.go
@@ -710,6 +710,39 @@ func (cm *ClientManager) GetNearestClient() (client *Client) {
 	return
 }
 
+// CallWithClientFailover runs fn with each connected client in latency order until fn
+// returns nil or a non-transient error. On transient errors (dropped connection, dead
+// genserver, cancelled RPC, timeouts, etc.) it tries the next relay.
+//
+// Prefer this over GetNearestClient for one-off CLI paths where a single bad relay
+// should not doom the command. For long-lived sessions that must stick to one node,
+// use GetNearestClient or GetClient as appropriate.
+func (cm *ClientManager) CallWithClientFailover(op string, fn func(*Client) error) error {
+	clients := cm.ClientsByLatency()
+	if len(clients) == 0 {
+		return fmt.Errorf("no rpc clients available")
+	}
+	var lastErr error
+	for i, c := range clients {
+		err := fn(c)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !IsTransientRPCError(err) {
+			return err
+		}
+		if i+1 < len(clients) {
+			host, herr := c.Host()
+			if herr != nil {
+				host = "unknown"
+			}
+			cm.Config.Logger.Info("%s: transient RPC error on %q, trying next relay (%d/%d): %v", op, host, i+1, len(clients), err)
+		}
+	}
+	return lastErr
+}
+
 // PeekNearestAddresses is a non-blocking version of GetNearestClient but can return nil
 func (cm *ClientManager) PeekNearestAddresses() (prim *util.Address, secd *util.Address) {
 	primClient, secdClient := cm.PeekNearestClients()

--- a/rpc/type.go
+++ b/rpc/type.go
@@ -6,7 +6,9 @@ package rpc
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -103,6 +105,46 @@ type RPCError struct {
 
 func (e RPCError) Error() string {
 	return e.Err.Message
+}
+
+// IsTransientRPCError reports whether err indicates a connection or client
+// actor failure that may succeed on another relay (e.g. dropped connection,
+// dead genserver after Close).
+func IsTransientRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ce CancelledError
+	if errors.As(err, &ce) {
+		return true
+	}
+	var te TimeoutError
+	if errors.As(err, &te) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "dead genserver") {
+		return true
+	}
+	if strings.Contains(msg, "rpc client was closed") {
+		return true
+	}
+	if strings.Contains(msg, "client disconnected") {
+		return true
+	}
+	if strings.Contains(msg, "connection reset") {
+		return true
+	}
+	if strings.Contains(msg, "broken pipe") {
+		return true
+	}
+	if strings.Contains(msg, "use of closed network connection") {
+		return true
+	}
+	if strings.Contains(msg, "connection refused") {
+		return true
+	}
+	return false
 }
 
 // WindowSize returns the current blockquick window size


### PR DESCRIPTION
One shot commands don't use the connection pool so if a relay EOFs the connection, the call fails.

e.g.:
hr@Hs-MacBook-Pro deploy % diode bns -lookup pipepline
INFO Diode Client version : v1.18.1 07 Apr 2026                       
INFO Checking for updates...
INFO No updates
INFO Client address       : 0xb6a70432a8bbbcb9ce019c9a9c82fd0f651be121
INFO Fleet address        : 0x8ad50255218a4abf89cae847189a4ba6ff8bb9e1
INFO Network is validated, last valid block: 10736693 0x00000e149424a37447358b4318e470e6d73110d2dab1e9c59a174381f6004212
INFO Client name          : nameabc01.diode                           
INFO Resolving BNS: pipepline server=us1.prenet.diode.io:41046 
INFO Resolving Moonbeam BNS: pipepline server=us1.prenet.diode.io:41046 
INFO Client connection closed unexpectedly: EOF server=us1.prenet.diode.io:41046 
ERROR Lookup error: : call to dead genserver
ERROR Couldn't execute command: call to dead genserver 

this PR adds a failover to use another client if this happens.
