### PR TITLE
fix(publish): register published ports before RPC clients start

### DIFF
--- a/cmd/diode/publish.go
+++ b/cmd/diode/publish.go
@@ -295,10 +295,6 @@ func publishHandler() (err error) {
 		}
 		portString[port.To] = port
 	}
-	err = app.Start()
-	if err != nil {
-		return
-	}
 	ports, err = parsePorts(cfg.PrivatePublishedPorts, config.PrivatePublishedMode)
 	if err != nil {
 		return
@@ -405,13 +401,21 @@ func publishHandler() (err error) {
 		os.Exit(2)
 	}
 
+	// Register published ports before app.Start() so RPC clients never handle
+	// inbound portopen while publishedPorts in the pool is still empty.
+	if len(cfg.PublishedPorts) > 0 {
+		app.clientManager.GetPool().SetPublishedPorts(cfg.PublishedPorts)
+	}
+	if err = app.Start(); err != nil {
+		return
+	}
+
 	if len(cfg.PublishedPorts) > 0 {
 		cfg.PrintInfo("")
 		name := cfg.ClientAddr.HexString()
 		if cfg.ClientName != "" {
 			name = cfg.ClientName
 		}
-		app.clientManager.GetPool().SetPublishedPorts(cfg.PublishedPorts)
 		for _, port := range cfg.PublishedPorts {
 			if port.Mode == config.PublicPublishedMode {
 				if port.To == httpPort {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses misleading **"Port was not published"** logs that could appear after server disconnects or at any time when using `diode publish`.

## Assessment

The log line is **not a red herring** in the sense that the client really did reject the inbound `portopen` with `errPortNotPublished` because `GetPublishedPort` returned nil. The **misleading part** was the *reason*: the port was configured, but the **DataPool had not been populated yet** because `publishHandler` called `app.Start()` (which starts RPC clients) **before** `SetPublishedPorts`.

Any inbound connection during that window would log "Port was not published" on **each** RPC server that delivered a `portopen`, which matches reports of the same message across eu1, us1, etc.

## Change

- Build the full `cfg.PublishedPorts` map (including static HTTP port if enabled).
- Call `SetPublishedPorts` **before** `app.Start()` so no `portopen` is handled with an empty `publishedPorts` map.

## Testing

`go test` could not be run in this environment (missing OpenSSL dev headers for `github.com/diodechain/openssl`). Please run tests locally in a full dev environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3617cad2-b7da-45f4-bd02-d0ad874f233b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3617cad2-b7da-45f4-bd02-d0ad874f233b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

