### PR TITLE
test(rpc): relay failover when one server disconnects

### DIFF
--- a/rpc/resolver.go
+++ b/rpc/resolver.go
@@ -15,6 +15,9 @@ import (
 
 var (
 	errOutdatedDeviceTicket = errors.New("outdated device ticket")
+
+	// testHookFetchAndValidate, when set, replaces fetchAndValidate in unit tests (nil = normal behavior).
+	testHookFetchAndValidate func(resolver *Resolver, client *Client, deviceID Address) (*edge.DeviceTicket, error)
 )
 
 // Resolver represents the bns name resolver of device
@@ -182,6 +185,9 @@ func uniqueClients(list []*Client) []*Client {
 }
 
 func (resolver *Resolver) fetchAndValidate(client *Client, deviceID Address) (*edge.DeviceTicket, error) {
+	if testHookFetchAndValidate != nil {
+		return testHookFetchAndValidate(resolver, client, deviceID)
+	}
 	device, err := client.GetObject(deviceID)
 	if err != nil {
 		return nil, err

--- a/rpc/resolver_failover_test.go
+++ b/rpc/resolver_failover_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/diodechain/diode_client/config"
+	"github.com/diodechain/diode_client/edge"
+	"github.com/diodechain/diode_client/util"
+)
+
+// TestFetchDeviceTicket_FailoverWhenFirstRelayFails verifies that fetchDeviceTicket
+// does not stop when the lowest-latency relay returns an error from GetObject; it
+// continues and succeeds on another relay in the pool (PR: single-server disconnect).
+func TestFetchDeviceTicket_FailoverWhenFirstRelayFails(t *testing.T) {
+	prevApp := config.AppConfig
+	defer func() { config.AppConfig = prevApp }()
+	prevHook := testHookFetchAndValidate
+	defer func() { testHookFetchAndValidate = prevHook }()
+
+	cfg := &config.Config{Debug: true}
+	logger, _ := config.NewLogger(cfg)
+	cfg.Logger = &logger
+	config.AppConfig = cfg
+
+	cm := NewClientManager(cfg)
+	pool := cm.GetPool()
+
+	var idA, idB util.Address
+	idA[19] = 0x0a
+	idB[19] = 0x0b
+
+	cA := NewClient("relay-a", cm, cfg, pool)
+	cA.serverID = idA
+	cB := NewClient("relay-b", cm, cfg, pool)
+	cB.serverID = idB
+	// Make cA the "nearest" by latency ordering used in ClientsByLatency.
+	cA.latencySum, cA.latencyCount = 100, 1
+	cB.latencySum, cB.latencyCount = 900, 1
+
+	cm.srv.Call(func() {
+		cm.clientMap[idA] = cA
+		cm.clientMap[idB] = cB
+		cm.clients = []*Client{cA, cB}
+		cm.doSortTopClients()
+	})
+
+	deviceID := util.Address{19: 0xdd}
+	okTicket := &edge.DeviceTicket{
+		Version:          0,
+		ServerID:         idB,
+		BlockNumber:      1,
+		BlockHash:        make([]byte, 32),
+		TotalConnections: big.NewInt(0),
+		TotalBytes:       big.NewInt(0),
+	}
+
+	testHookFetchAndValidate = func(_ *Resolver, client *Client, gotID Address) (*edge.DeviceTicket, error) {
+		if gotID != deviceID {
+			t.Errorf("unexpected device id")
+		}
+		if client == cA {
+			return nil, fmt.Errorf("simulated dead relay")
+		}
+		if client == cB {
+			return okTicket, nil
+		}
+		t.Fatalf("unexpected client %p", client)
+		return nil, fmt.Errorf("unexpected client")
+	}
+
+	resolver := NewResolver(Config{}, cm)
+	primary := cm.GetNearestClient()
+	if primary != cA {
+		t.Fatalf("expected nearest client relay-a, got %v", primary)
+	}
+
+	got, err := resolver.fetchDeviceTicket(primary, deviceID, util.Address{})
+	if err != nil {
+		t.Fatalf("fetchDeviceTicket: %v", err)
+	}
+	if got != okTicket {
+		t.Fatal("expected ticket from second relay")
+	}
+}
+
+// TestGetNearestClient_FailoverAfterPrimaryDisconnects verifies that when the
+// lowest-latency relay closes, GetNearestClient returns another live relay from
+// the pool instead of sticking to the dead connection.
+func TestGetNearestClient_FailoverAfterPrimaryDisconnects(t *testing.T) {
+	prevApp := config.AppConfig
+	defer func() { config.AppConfig = prevApp }()
+
+	cfg := &config.Config{Debug: true}
+	logger, _ := config.NewLogger(cfg)
+	cfg.Logger = &logger
+	config.AppConfig = cfg
+
+	cm := NewClientManager(cfg)
+	pool := cm.GetPool()
+
+	var id1, id2 util.Address
+	id1[19] = 0x01
+	id2[19] = 0x02
+
+	c1 := NewClient("relay-1", cm, cfg, pool)
+	c1.serverID = id1
+	c2 := NewClient("relay-2", cm, cfg, pool)
+	c2.serverID = id2
+	c1.latencySum, c1.latencyCount = 50, 1
+	c2.latencySum, c2.latencyCount = 500, 1
+
+	cm.srv.Call(func() {
+		cm.clientMap[id1] = c1
+		cm.clientMap[id2] = c2
+		cm.clients = []*Client{c1, c2}
+		cm.doSortTopClients()
+	})
+
+	if p := cm.GetNearestClient(); p != c1 {
+		t.Fatalf("expected c1 nearest, got %p", p)
+	}
+
+	c1.Close()
+
+	var next *Client
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		next = cm.GetNearestClient()
+		if next != nil && next != c1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if next == nil || next == c1 {
+		t.Fatalf("expected GetNearestClient to move off closed relay, got %p", next)
+	}
+	if next != c2 {
+		t.Fatalf("expected second relay to become nearest, got %p", next)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit tests and a small test hook so we can assert multi-relay behavior when the lowest-latency relay fails or disconnects.

## Investigation report (for review thread)

### Does the client "lose connection" when a single server disconnects?

**Partially — behavior depends on which layer you mean.**

1. **Relay pool (`ClientManager`)**  
   When a relay connection closes (`Client.Close` → `detachClient`), that relay is removed from `clientMap` and `clients`, and `doAddClient` runs in a loop to refill toward `targetClients` (default 5) using `doSelectNextHost` over `Config.RemoteRPCAddrs` that are not already connected. `GetNearestClient` / `topClient` skip closing clients and eventually pick the next best latency after `doSortTopClients`. So the **management layer is designed to move on**: the dead relay is dropped and others remain or are added.

2. **Inbound Goodbye** (`bridge` handling `edge.Goodbye`)  
   The affected `Client` is fully closed, same as above — not a soft failover of that TCP session; the pool is expected to compensate with other relays.

3. **Where users still see "stuck" behavior (matches PR description)**  
   - **`DataPool.ClosePorts(client)`** runs when a `Client` closes, which tears down **published port state tied to that client**. Published port config is global in the pool, but active inbound work was bound to the relay that died; there is no automatic migration of an existing gateway session to another relay in this path — new routing needs a valid ticket/path on the network side (as noted in review: ticket server ID vs global published ports).  
   - **Code paths that only use `GetNearestClient()` once** and do not retry on error (e.g. `ResolveRelayForDevice` uses a single client for `GetObject`/`GetNode`) can fail if that one relay is unhealthy even when another relay in the pool would work. That is a **narrow API gap**, not "no pool failover" globally.

4. **Resolver device tickets (`fetchDeviceTicket`)**  
   This path **does** iterate `ClientsByLatency()` (plus primary/preferred) and retries `fetchAndValidate` across relays; if one relay’s `GetObject` fails, it can still succeed on another. The new test documents and locks in that behavior.

### Conclusion

The client **does not** treat a single relay as the only possible connection forever: disconnect triggers detach + refill, and **resolution** over multiple relays is implemented in `fetchDeviceTicket`. Remaining pain for `.link` / published sites is likely the combination of **ticket/routing consistency** and **long-lived sessions/ports** not being transparently rebound, not the absence of any multi-relay logic in the manager.

### Tests added

- `TestFetchDeviceTicket_FailoverWhenFirstRelayFails` — first relay simulates `GetObject` failure; second relay returns the ticket.  
- `TestGetNearestClient_FailoverAfterPrimaryDisconnects` — after closing the nearest relay, `GetNearestClient` returns another registered relay.

### Implementation note

`testHookFetchAndValidate` in `resolver.go` is only for tests (nil in production) and mirrors the existing `testHookGetDefaultClientsUncached` pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64197e9b-2444-4dae-8902-1b7fd877da4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64197e9b-2444-4dae-8902-1b7fd877da4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

