### PR TITLE
Add `diode scp` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Top-level commands:
 - `files`: run a published HTTP file listener
 - `push` / `pull`: upload or download files from a Diode file listener
 - `ssh`: connect to a Diode target through an auto-managed local SOCKS proxy
+- `scp`: copy files to/from a Diode target through an auto-managed local SOCKS proxy
 - `join`: apply on-chain perimeter properties and optional WireGuard config
 - `bns`: register, transfer, and resolve BNS names
 - `query`: resolve a Diode address or name and print device tickets
@@ -320,6 +321,30 @@ Notes:
 - the command is marked beta in the client
 - do not put the port in the hostname; use `-p 22`, not `ubuntu@mymachine.diode:22`
 - OpenSSH tools such as `ssh` and `ssh-keygen` must be installed locally
+
+## SCP
+
+`diode scp` is the file-copy counterpart to `diode ssh`. It wraps the local
+`scp` binary using the same auto-managed Diode SOCKS proxy, ephemeral SSH
+identity, and `ProxyCommand` wiring, so remote paths that target a `.diode`
+host (or raw Diode address) get tunnelled through the Diode network.
+
+Examples:
+
+```bash
+./diode scp ./photo.jpg ubuntu@mymachine.diode:/tmp/photo.jpg
+./diode scp -P 22 ubuntu@mymachine.diode:/etc/hostname ./hostname
+./diode scp -r ./dir ubuntu@mymachine.diode:/tmp/dir
+```
+
+Notes:
+
+- same BETA status as `diode ssh`; flags may still change
+- just like `diode ssh`, do not put a port in the hostname; use `-P PORT`
+  (uppercase, as scp expects it)
+- OpenSSH tools (`scp`, `ssh`, `ssh-keygen`) must be installed locally
+- arguments after `scp` are passed through to the system scp, so standard
+  flags such as `-r`, `-p`, `-C`, `-o`, `-P`, etc. all work
 
 If you want to expose a normal local SSH daemon over Diode:
 

--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -101,6 +101,7 @@ func init() {
 	diodeCmd.AddSubCommand(tokenCmd)
 	diodeCmd.AddSubCommand(sshCmd)
 	diodeCmd.AddSubCommand(sshProxyCmd)
+	diodeCmd.AddSubCommand(scpCmd)
 	diodeCmd.AddSubCommand(versionCmd)
 	diodeCmd.AddSubCommand(updateCmd)
 	diodeCmd.AddSubCommand(mcpCmd)

--- a/cmd/diode/scp.go
+++ b/cmd/diode/scp.go
@@ -38,7 +38,7 @@ func scpHandler() error {
 // -l (bandwidth), -P (port; scp uses uppercase), and -S (ssh program).
 var scpOptsWithArg = map[string]bool{
 	"o": true, "c": true, "F": true, "i": true, "J": true,
-	"l": true, "P": true, "S": true,
+	"l": true, "P": true, "S": true, "D": true,
 }
 
 // extractSCPRemoteSpecs returns the set of scp remote specifications from

--- a/cmd/diode/scp.go
+++ b/cmd/diode/scp.go
@@ -1,0 +1,105 @@
+// Diode Network Client
+// Copyright 2026 Diode
+// Licensed under the Diode License, Version 1.1
+package main
+
+import (
+	"strings"
+
+	"github.com/diodechain/diode_client/command"
+)
+
+var (
+	scpCommandName = "scp"
+
+	scpCmd = &command.Command{
+		Name:            scpCommandName,
+		HelpText:        `  Copy files to/from a diode node via scp.`,
+		ExampleText:     `  diode scp ./photo.jpg ubuntu@mymachine.diode:/tmp/photo.jpg`,
+		Run:             scpHandler,
+		Type:            command.OneOffCommand,
+		PassThroughArgs: true,
+	}
+)
+
+func scpHandler() error {
+	return runSSHLikeTool(sshLikeToolOptions{
+		commandName:   scpCommandName,
+		toolName:      "scp",
+		validateLabel: "Invalid scp target",
+		validateArgs: func(args []string) error {
+			return validateSCPArgs(args)
+		},
+	})
+}
+
+// scpOptsWithArg lists scp short options that take a value in the next
+// argument. It is a superset of the options accepted by ssh, plus scp's own
+// -l (bandwidth), -P (port; scp uses uppercase), and -S (ssh program).
+var scpOptsWithArg = map[string]bool{
+	"o": true, "c": true, "F": true, "i": true, "J": true,
+	"l": true, "P": true, "S": true,
+}
+
+// extractSCPRemoteSpecs returns the set of scp remote specifications from
+// argv (in their original form, e.g. "user@host.diode:/tmp/x"). A remote
+// spec is any positional argument that contains a ':' before the first '/'
+// (matching OpenSSH scp's detection, which also excludes absolute local
+// paths).
+func extractSCPRemoteSpecs(args []string) []string {
+	var remotes []string
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if len(arg) == 2 && scpOptsWithArg[arg[1:2]] {
+				skipNext = true
+			}
+			continue
+		}
+		if isSCPRemoteSpec(arg) {
+			remotes = append(remotes, arg)
+		}
+	}
+	return remotes
+}
+
+// isSCPRemoteSpec reports whether arg looks like an scp remote file spec
+// ([user@]host:path) as opposed to a plain local path. Matches the rule
+// used by OpenSSH scp: a ':' before the first '/'.
+func isSCPRemoteSpec(arg string) bool {
+	if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, "./") || strings.HasPrefix(arg, "../") {
+		return false
+	}
+	slash := strings.Index(arg, "/")
+	colon := strings.Index(arg, ":")
+	if colon < 0 {
+		return false
+	}
+	if slash >= 0 && slash < colon {
+		return false
+	}
+	return true
+}
+
+// scpRemoteHost returns the [user@]host portion of an scp remote spec
+// (everything before the first ':').
+func scpRemoteHost(remote string) string {
+	colon := strings.Index(remote, ":")
+	if colon < 0 {
+		return remote
+	}
+	return remote[:colon]
+}
+
+func validateSCPArgs(args []string) error {
+	for _, remote := range extractSCPRemoteSpecs(args) {
+		if err := validateSSHTarget(scpRemoteHost(remote)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/diode/scp_test.go
+++ b/cmd/diode/scp_test.go
@@ -1,0 +1,157 @@
+// Diode Network Client
+// Copyright 2026 Diode
+// Licensed under the Diode License, Version 1.1
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestIsSCPRemoteSpec(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want bool
+	}{
+		{arg: "ubuntu@mymachine.diode:/tmp/x", want: true},
+		{arg: "mymachine.diode:/tmp/x", want: true},
+		{arg: "mymachine.diode:file.txt", want: true},
+		{arg: "0x1111111111111111111111111111111111111111:file", want: true},
+		{arg: "./local:file", want: false},
+		{arg: "/abs/local:file", want: false},
+		{arg: "../rel:file", want: false},
+		{arg: "localfile", want: false},
+		{arg: "dir/sub:file", want: false},
+		{arg: "./photo.jpg", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.arg, func(t *testing.T) {
+			got := isSCPRemoteSpec(tc.arg)
+			if got != tc.want {
+				t.Fatalf("isSCPRemoteSpec(%q) = %v, want %v", tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractSCPRemoteSpecs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "upload",
+			args: []string{"./photo.jpg", "ubuntu@mymachine.diode:/tmp/photo.jpg"},
+			want: []string{"ubuntu@mymachine.diode:/tmp/photo.jpg"},
+		},
+		{
+			name: "download",
+			args: []string{"ubuntu@mymachine.diode:/tmp/photo.jpg", "./photo.jpg"},
+			want: []string{"ubuntu@mymachine.diode:/tmp/photo.jpg"},
+		},
+		{
+			name: "remote to remote",
+			args: []string{"a@hosta.diode:/tmp/x", "b@hostb.diode:/tmp/x"},
+			want: []string{"a@hosta.diode:/tmp/x", "b@hostb.diode:/tmp/x"},
+		},
+		{
+			name: "with -P port and -r recursive flags",
+			args: []string{"-r", "-P", "22", "./dir", "ubuntu@mymachine.diode:/tmp/dir"},
+			want: []string{"ubuntu@mymachine.diode:/tmp/dir"},
+		},
+		{
+			name: "with -i identity swallowed",
+			args: []string{"-i", "./my.key", "mymachine.diode:file"},
+			want: []string{"mymachine.diode:file"},
+		},
+		{
+			name: "only local paths",
+			args: []string{"./a", "./b"},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractSCPRemoteSpecs(tc.args)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("extractSCPRemoteSpecs(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScpRemoteHost(t *testing.T) {
+	tests := []struct {
+		remote string
+		want   string
+	}{
+		{remote: "ubuntu@mymachine.diode:/tmp/x", want: "ubuntu@mymachine.diode"},
+		{remote: "mymachine.diode:file", want: "mymachine.diode"},
+		{remote: "mymachine.diode", want: "mymachine.diode"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.remote, func(t *testing.T) {
+			got := scpRemoteHost(tc.remote)
+			if got != tc.want {
+				t.Fatalf("scpRemoteHost(%q) = %q, want %q", tc.remote, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateSCPArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantErr  bool
+		contains []string
+	}{
+		{
+			name: "valid upload",
+			args: []string{"./photo.jpg", "ubuntu@mymachine.diode:/tmp/photo.jpg"},
+		},
+		{
+			name: "valid download with -P port",
+			args: []string{"-P", "22", "mymachine.diode:/etc/hostname", "./hostname"},
+		},
+		{
+			name: "valid raw address",
+			args: []string{"./a", "ubuntu@0x1111111111111111111111111111111111111111:/tmp/a"},
+		},
+		{
+			name:     "missing .diode suffix",
+			args:     []string{"./a", "ubuntu@mymachine:/tmp/a"},
+			wantErr:  true,
+			contains: []string{".diode", "ubuntu@mymachine.diode"},
+		},
+		{
+			name:     "missing .diode on download",
+			args:     []string{"ubuntu@mymachine:/tmp/a", "./a"},
+			wantErr:  true,
+			contains: []string{".diode"},
+		},
+		{
+			name: "only local paths",
+			args: []string{"./a", "./b"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSCPArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateSCPArgs(%v) expected error, got nil", tc.args)
+				}
+				for _, sub := range tc.contains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("validateSCPArgs(%v) error %q missing %q", tc.args, err.Error(), sub)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("validateSCPArgs(%v) unexpected error: %v", tc.args, err)
+			}
+		})
+	}
+}

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -142,12 +142,7 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 		os.Exit(1)
 	}
 
-	args := []string{
-		"-o", "ProxyCommand=" + buildSSHProxyCommand(runtimeGOOS, diodeExe, proxyAddr),
-		"-o", "StrictHostKeyChecking=accept-new",
-	}
-	args = append(args, passArgs...)
-	args = append(args, "-i", identityFile)
+	args := buildSSHLikeToolArgs(runtimeGOOS, diodeExe, proxyAddr, identityFile, passArgs)
 
 	cmd := exec.Command(toolPath, args...)
 	cmd.Stdin = os.Stdin
@@ -163,6 +158,20 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 		os.Exit(1)
 	}
 	return nil
+}
+
+// buildSSHLikeToolArgs builds the argv (excluding argv[0]) for an OpenSSH
+// tool launched by diode. The user's pass-through args are placed *after*
+// the diode-injected flags so positional arguments (e.g. scp's source/
+// destination) keep their meaning. Putting -i after the user args breaks
+// scp because the identity path looks like an extra positional.
+func buildSSHLikeToolArgs(goos string, diodeExe string, proxyAddr string, identityFile string, passArgs []string) []string {
+	args := []string{
+		"-o", "ProxyCommand=" + buildSSHProxyCommand(goos, diodeExe, proxyAddr),
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-i", identityFile,
+	}
+	return append(args, passArgs...)
 }
 
 func normalizeSSHArgs(args []string) []string {

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -44,9 +44,46 @@ var (
 
 var runtimeGOOS = runtime.GOOS
 
-func sshHandler() (err error) {
+func sshHandler() error {
+	return runSSHLikeTool(sshLikeToolOptions{
+		commandName:   sshCommandName,
+		toolName:      "ssh",
+		validateLabel: "Invalid SSH target",
+		validateArgs: func(args []string) error {
+			if target := extractSSHTarget(args); target != "" {
+				return validateSSHTarget(target)
+			}
+			return nil
+		},
+	})
+}
+
+// sshLikeToolOptions configures runSSHLikeTool for a specific OpenSSH-based
+// diode subcommand (e.g. `diode ssh`, `diode scp`).
+type sshLikeToolOptions struct {
+	// commandName is the diode subcommand name as it appears on the command
+	// line (for example "ssh" or "scp").
+	commandName string
+	// toolName is the external OpenSSH tool to exec (for example "ssh" or
+	// "scp"). It defaults to commandName when empty.
+	toolName string
+	// validateArgs is an optional validator for the pass-through arguments.
+	validateArgs func(args []string) error
+	// validateLabel is used as the error label if validateArgs returns an
+	// error.
+	validateLabel string
+}
+
+// runSSHLikeTool runs an OpenSSH tool (ssh, scp) over a temporary local
+// SOCKS proxy that bridges into the Diode network, using an ephemeral
+// identity and a ProxyCommand that tunnels via `diode ssh-proxy`.
+func runSSHLikeTool(opts sshLikeToolOptions) error {
 	cfg := config.AppConfig
-	cfg.Logger.Warn("ssh command is still BETA, parameters may change")
+	toolName := opts.toolName
+	if toolName == "" {
+		toolName = opts.commandName
+	}
+	cfg.Logger.Warn("%s command is still BETA, parameters may change", opts.commandName)
 
 	if err := app.Start(); err != nil {
 		cfg.PrintError("Could not start local Diode client", err)
@@ -66,30 +103,28 @@ func sshHandler() (err error) {
 		os.Exit(1)
 	}
 
-	args := []string{
-		"ssh",
-		"-o", "ProxyCommand=" + buildSSHProxyCommand(runtimeGOOS, diodeExe, proxyAddr),
-		"-o", "StrictHostKeyChecking=accept-new",
-	}
 	os_args := os.Args
-	// Remove all args before the ssh command by finding "ssh" and removing all args before it
-	ssh_index := -1
+	cmdIndex := -1
 	for i, arg := range os_args {
-		if arg == "ssh" {
-			ssh_index = i
+		if arg == opts.commandName {
+			cmdIndex = i
 			break
 		}
 	}
-	if ssh_index == -1 {
-		cfg.PrintError("ssh command not found", errors.New("ssh command not found"))
+	if cmdIndex == -1 {
+		msg := fmt.Sprintf("%s command not found", opts.commandName)
+		cfg.PrintError(msg, errors.New(msg))
 		os.Exit(1)
 	}
-	sshArgs := normalizeSSHArgs(os_args[ssh_index+1:])
-	args = append(args, sshArgs...)
+	passArgs := normalizeSSHArgs(os_args[cmdIndex+1:])
 
-	if target := extractSSHTarget(sshArgs); target != "" {
-		if err := validateSSHTarget(target); err != nil {
-			cfg.PrintError("Invalid SSH target", err)
+	if opts.validateArgs != nil {
+		if err := opts.validateArgs(passArgs); err != nil {
+			label := opts.validateLabel
+			if label == "" {
+				label = fmt.Sprintf("Invalid %s argument", opts.commandName)
+			}
+			cfg.PrintError(label, err)
 			os.Exit(1)
 		}
 	}
@@ -100,28 +135,34 @@ func sshHandler() (err error) {
 		os.Exit(1)
 	}
 	defer cleanup()
-	args = append(args, "-i", identityFile)
 
-	ssh, err := findOpenSSHTool("ssh")
+	toolPath, err := findOpenSSHTool(toolName)
 	if err != nil {
-		cfg.PrintError("ssh not found", err)
+		cfg.PrintError(fmt.Sprintf("%s not found", toolName), err)
 		os.Exit(1)
 	}
-	cmd := exec.Command(ssh, args[1:]...)
+
+	args := []string{
+		"-o", "ProxyCommand=" + buildSSHProxyCommand(runtimeGOOS, diodeExe, proxyAddr),
+		"-o", "StrictHostKeyChecking=accept-new",
+	}
+	args = append(args, passArgs...)
+	args = append(args, "-i", identityFile)
+
+	cmd := exec.Command(toolPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
-	err = cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())
 		}
-		cfg.PrintError("Could not execute ssh", err)
+		cfg.PrintError(fmt.Sprintf("Could not execute %s", toolName), err)
 		os.Exit(1)
 	}
-	return
+	return nil
 }
 
 func normalizeSSHArgs(args []string) []string {

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -106,6 +106,33 @@ func TestBuildSSHProxyCommand(t *testing.T) {
 	}
 }
 
+func TestBuildSSHLikeToolArgsKeepsUserArgsLast(t *testing.T) {
+	passArgs := []string{
+		"openssl-1.1.1w.tar.gz",
+		"ubuntu@miner2023.diode:/home/ubuntu/test.tgz",
+	}
+	got := buildSSHLikeToolArgs("linux", "/usr/local/bin/diode", "127.0.0.1:1080", "/tmp/diode-ssh-1/id_ed25519", passArgs)
+
+	// The user's pass-through args must be the trailing args so that
+	// scp's source/destination positionals keep their meaning. -i and the
+	// other diode-injected flags must come before them.
+	want := []string{
+		"-o", "ProxyCommand=/usr/local/bin/diode ssh-proxy -proxy-addr 127.0.0.1:1080 %h %p",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-i", "/tmp/diode-ssh-1/id_ed25519",
+		"openssl-1.1.1w.tar.gz",
+		"ubuntu@miner2023.diode:/home/ubuntu/test.tgz",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("buildSSHLikeToolArgs() len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("buildSSHLikeToolArgs()[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestFindOpenSSHToolWindowsInstallHelp(t *testing.T) {
 	origLookPath := lookPath
 	origGOOS := runtimeGOOS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a new top-level subcommand `diode scp` that provides `scp`-style file
transfers through the Diode network, in the same way that `diode ssh`
provides `ssh`-style interactive sessions today.

Most of the heavy lifting (start the local Diode client, bring up a
temporary local SOCKS proxy, derive an ephemeral SSH identity, wire a
`ProxyCommand` that tunnels through `diode ssh-proxy`, forward stdio, and
propagate the child's exit code) is shared with `diode ssh`. To avoid
duplicating this logic, the existing body of `sshHandler` has been
extracted into a reusable helper, `runSSHLikeTool`. Both `sshHandler` and
the new `scpHandler` are now thin configurations of that helper.

## Changes

- `cmd/diode/ssh.go`: extract `runSSHLikeTool` plus an
  `sshLikeToolOptions` struct that captures the subcommand name, the
  OpenSSH binary to exec, and an optional per-command argument validator.
  `sshHandler` now just plugs in the existing `extractSSHTarget`/
  `validateSSHTarget` logic. No behavior change for `diode ssh`.
- `cmd/diode/scp.go` (new): defines the `scp` subcommand and its
  argument-validation helpers:
  - `extractSCPRemoteSpecs` walks pass-through args while respecting scp's
    short options that take a value (including scp-specific ones like
    `-P`, `-l`, `-S`) and returns each positional argument that looks
    like `[user@]host:path` using the same rule OpenSSH scp uses (first
    `:` before the first `/`).
  - `scpRemoteHost` strips the `:path` suffix so we can feed the host
    portion back into the existing `validateSSHTarget`, which reuses the
    same "missing `.diode`" / "port in hostname" error messages as
    `diode ssh`.
- `cmd/diode/app.go`: register `scpCmd` alongside `sshCmd`/`sshProxyCmd`.
- `cmd/diode/scp_test.go` (new): unit tests for `isSCPRemoteSpec`,
  `extractSCPRemoteSpecs`, `scpRemoteHost`, and `validateSCPArgs`
  (uploads, downloads, remote-to-remote copies, `-r`, `-P`, `-i`,
  missing `.diode` suffix, local-only paths, etc.).
- `README.md`: document the new `scp` subcommand next to the existing
  `ssh` section.

## Usage

```bash
./diode scp ./photo.jpg ubuntu@mymachine.diode:/tmp/photo.jpg
./diode scp -P 22 ubuntu@mymachine.diode:/etc/hostname ./hostname
./diode scp -r ./dir ubuntu@mymachine.diode:/tmp/dir
```

## Validation

- `go build ./...` passes.
- `go vet ./cmd/diode/` is clean.
- `go test ./cmd/diode/` passes, including the new scp tests and the
  existing ssh / ssh-proxy tests (no regressions from the refactor).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8562cbd0-84a2-4385-a28b-0f2e4a9044eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8562cbd0-84a2-4385-a28b-0f2e4a9044eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

