### PR TITLE
Speed up member resolution for private publish

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -77,8 +77,8 @@ type Client struct {
 
 	closed  atomic.Bool // set true when fully closed (atomic: read from any goroutine e.g. Start/recv loops)
 	closing uint32      // set before Close() callback runs; allows GetNearestClient to exclude client earlier
-	srv      *genserver.GenServer
-	timer    *Timer
+	srv     *genserver.GenServer
+	timer   *Timer
 
 	portOpen2Handler atomic.Value
 }
@@ -1066,6 +1066,25 @@ func (client *Client) GetMoonAccountValueRaw(account [20]byte, rawKey []byte) ([
 	return nil, nil
 }
 
+func (client *Client) getMoonAccountValuesRaw(account [20]byte, rawKeys [][]byte) ([][]byte, []error) {
+	raws := make([][]byte, len(rawKeys))
+	errs := make([]error, len(rawKeys))
+	if len(rawKeys) == 0 {
+		return raws, errs
+	}
+
+	var wg sync.WaitGroup
+	for i, rawKey := range rawKeys {
+		wg.Add(1)
+		go func(i int, rawKey []byte) {
+			defer wg.Done()
+			raws[i], errs[i] = client.GetMoonAccountValueRaw(account, rawKey)
+		}(i, rawKey)
+	}
+	wg.Wait()
+	return raws, errs
+}
+
 func (client *Client) GetMoonAccountValueInt(addr [20]byte, key []byte) *big.Int {
 	raw, err := client.GetMoonAccountValueRaw(addr, key)
 	ret := big.NewInt(0)
@@ -1134,6 +1153,70 @@ func (client *Client) GetAccountValueRaw(blockNumber uint64, addr [20]byte, key 
 		return NullData, err
 	}
 	return raw, nil
+}
+
+func (client *Client) getAccountValuesRaw(blockNumber uint64, addr [20]byte, rawKeys [][]byte) ([][]byte, []error) {
+	if blockNumber <= 0 {
+		bn, _ := client.LastValid()
+		blockNumber = uint64(bn)
+	}
+	raws := make([][]byte, len(rawKeys))
+	errs := make([]error, len(rawKeys))
+	if len(rawKeys) == 0 {
+		return raws, errs
+	}
+
+	keys := make([][]byte, len(rawKeys))
+	values := make([]*edge.AccountValue, len(rawKeys))
+	var roots *edge.AccountRoots
+	var rootsErr error
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		roots, rootsErr = client.GetAccountRoots(blockNumber, addr)
+	}()
+
+	for i, rawKey := range rawKeys {
+		keys[i] = util.PaddingBytesPrefix(rawKey, 0, 32)
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			values[i], errs[i] = client.GetAccountValue(blockNumber, addr, keys[i])
+		}(i)
+	}
+	wg.Wait()
+
+	for i, acv := range values {
+		if errs[i] != nil {
+			raws[i] = NullData
+			continue
+		}
+		if rootsErr != nil {
+			raws[i] = NullData
+			errs[i] = rootsErr
+			continue
+		}
+		if acv == nil || roots == nil {
+			raws[i] = NullData
+			errs[i] = fmt.Errorf("empty account value")
+			continue
+		}
+		acvTree := acv.AccountTree()
+		// Verify the calculated proof value matches the specific known root.
+		if roots.Find(acv.AccountRoot()) != int(acvTree.Modulo) {
+			client.config.Logger.Error("Received wrong merkle proof %v != %v", roots.Find(acv.AccountRoot()), int(acvTree.Modulo))
+			errs[i] = fmt.Errorf("wrong merkle proof")
+			raws[i] = NullData
+			continue
+		}
+		raws[i], errs[i] = acvTree.Get(keys[i])
+		if errs[i] != nil {
+			raws[i] = NullData
+		}
+	}
+	return raws, errs
 }
 
 // GetAccountRoots returns account state roots
@@ -1383,12 +1466,23 @@ func (client *Client) ResolveMembers(members Address) (addr []Address, err error
 func (client *Client) ResolveDiodeMembers(members Address) (addr []Address, err error) {
 	blockNumber, _ := client.LastValid()
 
-	owner := client.GetAccountValueAddress(blockNumber, members, contract.OwnerLocation())
+	raws, errs := client.getAccountValuesRaw(blockNumber, members, [][]byte{
+		contract.OwnerLocation(),
+		contract.MemberIndex(),
+	})
+
+	var owner Address
+	if errs[0] == nil {
+		copy(owner[:], raws[0][12:])
+	}
 	if owner != [20]byte{} {
 		addr = append(addr, owner)
 	}
 
-	size := int(client.GetAccountValueInt(blockNumber, members, contract.MemberIndex()).Uint64())
+	size := 0
+	if errs[1] == nil {
+		size = int(new(big.Int).SetBytes(raws[1]).Uint64())
+	}
 
 	// Safety belt, to protect against unreasonable allocation.
 	if size > 128 {
@@ -1396,8 +1490,16 @@ func (client *Client) ResolveDiodeMembers(members Address) (addr []Address, err 
 		size = 0
 	}
 
+	keys := make([][]byte, size)
+	for i := range keys {
+		keys[i] = contract.MemberLocation(i)
+	}
+	raws, errs = client.getAccountValuesRaw(blockNumber, members, keys)
 	for i := 0; i < size; i++ {
-		address := client.GetAccountValueAddress(blockNumber, members, contract.MemberLocation(i))
+		var address Address
+		if errs[i] == nil {
+			copy(address[:], raws[i][12:])
+		}
 		if address != owner && address != [20]byte{} {
 			addr = append(addr, address)
 		}
@@ -1406,12 +1508,23 @@ func (client *Client) ResolveDiodeMembers(members Address) (addr []Address, err 
 }
 
 func (client *Client) ResolveMoonMembers(members Address) (addr []Address, err error) {
-	owner := client.GetMoonAccountValueAddress(members, contract.OwnerLocation())
+	raws, errs := client.getMoonAccountValuesRaw(members, [][]byte{
+		contract.OwnerLocation(),
+		contract.MemberIndex(),
+	})
+
+	var owner Address
+	if errs[0] == nil {
+		copy(owner[:], raws[0][12:])
+	}
 	if owner != [20]byte{} {
 		addr = append(addr, owner)
 	}
 
-	size := int(client.GetMoonAccountValueInt(members, contract.MemberIndex()).Uint64())
+	size := 0
+	if errs[1] == nil {
+		size = int(new(big.Int).SetBytes(raws[1]).Uint64())
+	}
 
 	// Safety belt, to protect against unreasonable allocation.
 	if size > 128 {
@@ -1419,8 +1532,16 @@ func (client *Client) ResolveMoonMembers(members Address) (addr []Address, err e
 		size = 0
 	}
 
+	keys := make([][]byte, size)
+	for i := range keys {
+		keys[i] = contract.MemberLocation(i)
+	}
+	raws, errs = client.getMoonAccountValuesRaw(members, keys)
 	for i := 0; i < size; i++ {
-		address := client.GetMoonAccountValueAddress(members, contract.MemberLocation(i))
+		var address Address
+		if errs[i] == nil {
+			copy(address[:], raws[i][12:])
+		}
 		if address != owner && address != [20]byte{} {
 			addr = append(addr, address)
 		}

--- a/rpc/datapool.go
+++ b/rpc/datapool.go
@@ -6,6 +6,7 @@ package rpc
 import (
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/diodechain/diode_client/config"
@@ -15,6 +16,8 @@ import (
 	"github.com/diodechain/openssl"
 	"github.com/dominicletz/genserver"
 )
+
+const resolveMembersConcurrency = 8
 
 type DataPool struct {
 	locks          map[string]bool
@@ -240,36 +243,53 @@ func (p *DataPool) updateCacheResolveBNS(deviceName string, client *Client) {
 }
 
 func resolveAllPeersOfAddrs(members []Address, client *Client) (peers []Address) {
-	for _, maybePeerAddr := range members {
-		members, new_err := client.ResolveMembers(maybePeerAddr)
-		if new_err == nil {
-			//if member count is 1 and member is itself, it is a peer.
-			if len(members) == 1 && members[0] == maybePeerAddr {
-				peers = append(peers, maybePeerAddr)
-				continue
-			}
-			// check if members list includes itself to prevent infinite loop. If so, delete itself from members list
-			for i, member := range members {
-				if member == maybePeerAddr {
-					members = append(members[:i], members[i+1:]...)
-					break
-				}
-			}
-			// smart contract, might need to recurse
-			peers = append(peers, resolveAllPeersOfAddrs(members, client)...)
-		} else {
-			// not a smart contract, instead a real (device) peer
-			peers = append(peers, maybePeerAddr)
-			// log peers
-			peersString := "["
-			for _, peer := range peers {
-				peersString += peer.HexString() + ", "
-			}
-			peersString = peersString[:len(peersString)-2] + "]"
-			client.Log().Debug("Resolved all peers of %s. Peers list is %v", maybePeerAddr.HexString(), peersString)
-		}
+	sem := make(chan struct{}, resolveMembersConcurrency)
+	return resolveAllPeersOfAddrsWithLimit(members, client, sem)
+}
+
+func resolveAllPeersOfAddrsWithLimit(members []Address, client *Client, sem chan struct{}) (peers []Address) {
+	if len(members) == 0 {
+		return nil
+	}
+
+	resolved := make([][]Address, len(members))
+	var wg sync.WaitGroup
+	for i, maybePeerAddr := range members {
+		wg.Add(1)
+		go func(i int, maybePeerAddr Address) {
+			defer wg.Done()
+			resolved[i] = resolvePeerAddr(maybePeerAddr, client, sem)
+		}(i, maybePeerAddr)
+	}
+	wg.Wait()
+
+	for _, addrs := range resolved {
+		peers = append(peers, addrs...)
 	}
 	return peers
+}
+
+func resolvePeerAddr(maybePeerAddr Address, client *Client, sem chan struct{}) []Address {
+	sem <- struct{}{}
+	members, err := client.ResolveMembers(maybePeerAddr)
+	<-sem
+
+	if err != nil {
+		return []Address{maybePeerAddr}
+	}
+	// If member count is 1 and member is itself, it is a peer.
+	if len(members) == 1 && members[0] == maybePeerAddr {
+		return []Address{maybePeerAddr}
+	}
+	// Check if members list includes itself to prevent infinite recursion.
+	for i, member := range members {
+		if member == maybePeerAddr {
+			members = append(members[:i], members[i+1:]...)
+			break
+		}
+	}
+	// Smart contract, might need to recurse.
+	return resolveAllPeersOfAddrsWithLimit(members, client, sem)
 }
 
 func (p *DataPool) Lock(name string) {


### PR DESCRIPTION
This pull request introduces significant performance improvements and code refactoring for resolving member addresses and retrieving account values in the `rpc` package. The main focus is on parallelizing and batching account value lookups, as well as adding concurrency limits to recursive peer resolution to prevent resource exhaustion.

**Performance and concurrency improvements:**

* Added new batched and parallelized methods (`getMoonAccountValuesRaw` and `getAccountValuesRaw`) to retrieve multiple account values concurrently, reducing latency for bulk lookups. [[1]](diffhunk://#diff-bcca4c7258b402c27ba36f7d0889e36df3bf4b9fa9556a64a0dfd57d95e384fcR1069-R1087) [[2]](diffhunk://#diff-bcca4c7258b402c27ba36f7d0889e36df3bf4b9fa9556a64a0dfd57d95e384fcR1158-R1221)
* Refactored `ResolveDiodeMembers` and `ResolveMoonMembers` to use the new batched account value retrieval methods, minimizing sequential network calls and improving efficiency. [[1]](diffhunk://#diff-bcca4c7258b402c27ba36f7d0889e36df3bf4b9fa9556a64a0dfd57d95e384fcL1386-R1502) [[2]](diffhunk://#diff-bcca4c7258b402c27ba36f7d0889e36df3bf4b9fa9556a64a0dfd57d95e384fcL1409-R1544)

**Recursive peer resolution enhancements:**

* Refactored the peer resolution logic in `datapool.go` to use a recursive, concurrency-limited approach (`resolveAllPeersOfAddrsWithLimit` and `resolvePeerAddr`), preventing excessive goroutine spawning and potential stack overflows during deep recursion.
* Introduced a concurrency limit constant (`resolveMembersConcurrency`) and used a semaphore pattern to cap the number of concurrent member resolution goroutines.

**Code maintenance:**

* Added necessary imports for `sync` to support the new concurrency features.