### PR TITLE
Add Cursor Cloud specific development instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ This is a self-contained Go CLI (`diode`) with no local service dependencies (no
 - Go 1.25.x (pre-installed; version pinned in `.tool-versions`)
 - Go runtime patch (`./patch_runtime.sh`) — adds `GetGoID()` to the Go runtime; idempotent
 - OpenSSL build (`SUDO=sudo make openssl`) — builds the CGO OpenSSL binding; idempotent
-- `staticcheck` installed via `cd tools && go install ...`
+- `staticcheck` installed via `cd tools && go install honnef.co/go/tools/cmd/staticcheck@latest`
 
 ### Key commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,37 @@ Before handing back a change, verify:
 - concurrency edits preserve ownership and shutdown semantics
 - if behavior changed at the CLI or network level, isolated clients were started with `-dbpath` and the flow was manually tested
 - verification was run, or you clearly state what was not run
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+This is a self-contained Go CLI (`diode`) with no local service dependencies (no databases, message queues, or Docker containers). The only external runtime dependency is outbound internet to Diode relay nodes (`*.prenet.diode.io:41046`).
+
+### Build prerequisites (already handled by the update script)
+
+- Go 1.25.x (pre-installed; version pinned in `.tool-versions`)
+- Go runtime patch (`./patch_runtime.sh`) — adds `GetGoID()` to the Go runtime; idempotent
+- OpenSSL build (`SUDO=sudo make openssl`) — builds the CGO OpenSSL binding; idempotent
+- `staticcheck` installed via `cd tools && go install ...`
+
+### Key commands
+
+| Action | Command |
+|--------|---------|
+| Build binary | `make diode` |
+| Run tests | `make test` |
+| Run cmd/diode tests | `go test -tags patch_runtime ./cmd/diode/...` |
+| Format | `make format` |
+| Lint | `make lint` (runs `go vet` + `staticcheck`) |
+| Run app | `./diode -update=false <subcommand>` |
+
+### Gotchas
+
+- Always pass `-update=false` when running `./diode` in CI or cloud environments to skip the auto-updater.
+- Use `-dbpath /tmp/<unique>/private.db` for isolated test runs to avoid corrupting shared state.
+- The `make openssl` target requires `sudo` on Linux (`SUDO=sudo make openssl`).
+- `patch_runtime.sh` needs write access to `$(go env GOROOT)/src/runtime/runtime.go`; this is already writable in the cloud agent VM.
+- The Makefile excludes `cmd` packages from `make test`; run `go test -tags patch_runtime ./cmd/diode/...` separately if needed.
+- Build tag `patch_runtime` is required for compilation (the Makefile sets it automatically).
+- Network-dependent tests (e.g., `ci_test.sh`) require live internet access to Diode relays.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with:

- Environment overview (self-contained Go CLI, no local service deps)
- Build prerequisites summary (handled by the VM update script)
- Key commands table (build, test, format, lint, run)
- Gotchas for cloud agent environments (auto-updater, isolated DB paths, sudo for OpenSSL, build tags, network tests)

This helps future cloud agents start developing immediately without re-discovering setup steps.

**Evidence of working environment:**

[diode_time_output.log](https://cursor.com/artifacts/c/art-0076b9b5-8524-462e-9f02-9a082046c2bd)

[diode_config_output.log](https://cursor.com/artifacts/c/art-39985900-c001-4615-b7be-ee0571252be5)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f061b4dd-cb07-4a72-8ffc-a03696f2f13c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f061b4dd-cb07-4a72-8ffc-a03696f2f13c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

