### PR TITLE
Fix CI: SOCKS double-bind and shared-control test teardown

### DIFF
--- a/cmd/diode/control_shared_test.go
+++ b/cmd/diode/control_shared_test.go
@@ -64,6 +64,9 @@ func setupSharedControlTestEnv(t *testing.T, cfg *config.Config) {
 	db.DB = testDB
 
 	t.Cleanup(func() {
+		if app != nil && app != origApp {
+			app.Close()
+		}
 		app = origApp
 		config.AppConfig = origCfg
 		db.DB = origDB

--- a/rpc/socks.go
+++ b/rpc/socks.go
@@ -89,9 +89,12 @@ type Server struct {
 }
 
 func (socksServer *Server) Addr() net.Addr {
+	if socksServer == nil {
+		return nil
+	}
 	socksServer.netMu.RLock()
 	defer socksServer.netMu.RUnlock()
-	if socksServer == nil || socksServer.listener == nil {
+	if socksServer.listener == nil {
 		return nil
 	}
 	return socksServer.listener.Addr()
@@ -891,6 +894,14 @@ func (socksServer *Server) Start() error {
 	}
 
 	if socksServer.Config.EnableSocks {
+		socksServer.netMu.Lock()
+		already := socksServer.listener != nil && socksServer.udpconn != nil
+		socksServer.netMu.Unlock()
+		if already {
+			// SetConfig already started listeners for a newly constructed server
+			// (see NewSocksServer); starting again would bind the same address twice.
+			return nil
+		}
 		return socksServer.startSocksListeners()
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targets CI failures on `TestReconcileControlServicesReusesSocksServerForBindOnlyChanges` (second bind on the same SOCKS address) and intermittent `cmd/diode` panics from `persistLastValidRecord` with nil `db.DB` after tests restored globals while RPC goroutines were still running.

- **SOCKS `Start()` idempotency:** `NewSocksServer` already starts listeners via `SetConfig` when `EnableSocks` is true; `Start()` now skips if TCP and UDP listeners are already active.
- **Shared control tests:** `setupSharedControlTestEnv` calls `app.Close()` before restoring global `app` / `db.DB`.
- **`Server.Addr()`:** nil receiver check before locking (staticcheck SA5011).

## Test plan

- [x] `go test ./...`
- [x] `make lint`

Stacked on the socksd regression branch for integration with PR #292.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2e0e0d7-813c-4ba8-ba7e-d869e778e23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2e0e0d7-813c-4ba8-ba7e-d869e778e23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

