### PR TITLE
Re-support -fleet in global flags

### DIFF
--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -68,8 +68,7 @@ func init() {
 	diodeCmd.Flag.StringVar(&cfg.MutexProfile, "mutexprofile", "", "file path for mutex profiling")
 	diodeCmd.Flag.IntVar(&cfg.MutexProfileRate, "mutexprofilerate", 1, "the fraction of mutex contention events that are reported in the mutex profile")
 
-	var fleetFake string
-	diodeCmd.Flag.StringVar(&fleetFake, "fleet", "", "@deprecated. Use: 'diode config set fleet=0x1234' instead")
+	diodeCmd.Flag.String("fleet", "", "fleet contract address (0x...) for this invocation only; use 'diode config -set fleet=0x...' to persist")
 
 	diodeCmd.Flag.DurationVar(&cfg.RemoteRPCTimeout, "timeout", 5*time.Second, "timeout seconds to connect to the remote rpc server")
 	diodeCmd.Flag.DurationVar(&cfg.RetryWait, "retrywait", 1*time.Second, "wait seconds before next retry")
@@ -393,6 +392,9 @@ func (dio *Diode) Start() error {
 		return fmt.Errorf("could not determine command to start")
 	}
 	if err := dio.loadPersistedSharedControls(); err != nil {
+		return err
+	}
+	if err := applyFleetCLIOverride(&diodeCmd.Flag, dio.config); err != nil {
 		return err
 	}
 	cfg.PrintLabel("Client address", cfg.ClientAddr.HexString())

--- a/cmd/diode/control_shared.go
+++ b/cmd/diode/control_shared.go
@@ -1239,6 +1239,37 @@ func commitControlConfig(dst *config.Config, src *config.Config) {
 	dst.SetBlocklists(src.CloneBlocklists())
 }
 
+// applyFleetCLIOverride applies -fleet when it was passed on the command line.
+// It does not persist over restarts unless in the flag again.
+func applyFleetCLIOverride(fs *flag.FlagSet, cfg *config.Config) error {
+	if fs == nil || cfg == nil {
+		return nil
+	}
+	var (
+		fleetSet   bool
+		fleetValue string
+	)
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "fleet" {
+			fleetSet = true
+			fleetValue = f.Value.String()
+		}
+	})
+	if !fleetSet {
+		return nil
+	}
+	fleetValue = strings.TrimSpace(fleetValue)
+	if fleetValue == "" {
+		return fmt.Errorf("-fleet requires a contract address (0x...)")
+	}
+	addr, err := util.DecodeAddress(fleetValue)
+	if err != nil {
+		return fmt.Errorf("invalid -fleet address %q: %w", fleetValue, err)
+	}
+	cfg.FleetAddr = addr
+	return nil
+}
+
 func (dio *Diode) loadPersistedSharedControls() error {
 	if dio.controlsLoaded || dio.config.LoadFromFile || db.DB == nil || dio.cmd == nil {
 		dio.controlsLoaded = true

--- a/cmd/diode/control_shared_test.go
+++ b/cmd/diode/control_shared_test.go
@@ -105,6 +105,41 @@ func TestApplySharedControlValueAndReset(t *testing.T) {
 	}
 }
 
+func TestApplyFleetCLIOverride(t *testing.T) {
+	cfg := newSharedControlTestConfig(t)
+	cfg.FleetAddr = config.DefaultFleetAddr
+
+	const overrideHex = "0x1234567890123456789012345678901234567890"
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("fleet", "", "")
+	if err := applyFleetCLIOverride(fs, cfg); err != nil {
+		t.Fatalf("no flag: %v", err)
+	}
+	if cfg.FleetAddr != config.DefaultFleetAddr {
+		t.Fatalf("expected default fleet unchanged, got %s", cfg.FleetAddr.HexString())
+	}
+
+	if err := fs.Parse([]string{"-fleet", overrideHex}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := applyFleetCLIOverride(fs, cfg); err != nil {
+		t.Fatalf("with flag: %v", err)
+	}
+	if cfg.FleetAddr.HexString() != strings.ToLower(overrideHex) {
+		t.Fatalf("fleet = %s, want %s", cfg.FleetAddr.HexString(), strings.ToLower(overrideHex))
+	}
+
+	fs2 := flag.NewFlagSet("test2", flag.ContinueOnError)
+	fs2.String("fleet", "", "")
+	if err := fs2.Parse([]string{"-fleet", ""}); err != nil {
+		t.Fatalf("Parse empty: %v", err)
+	}
+	if err := applyFleetCLIOverride(fs2, cfg); err == nil {
+		t.Fatal("expected error for empty -fleet")
+	}
+}
+
 func TestApplyControlPatchRejectsAtomically(t *testing.T) {
 	cfg := newSharedControlTestConfig(t)
 

--- a/cmd/diode/socks_integration_test.go
+++ b/cmd/diode/socks_integration_test.go
@@ -24,7 +24,7 @@ func TestSocksDefaultPortFree(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "db1")
 
 	// Start diode publish without -socksd
-	cmd := exec.Command(binPath, "-fleet", "127.0.0.1:9999", "-dbpath", dbPath, "publish", "-public", "8080:80")
+	cmd := exec.Command(binPath, "-dbpath", dbPath, "publish", "-public", "8080:80")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stdout
@@ -55,7 +55,7 @@ func TestParallelDiodeClients(t *testing.T) {
 	dbPath2 := filepath.Join(t.TempDir(), "db2")
 
 	// Start first diode
-	cmd1 := exec.Command(binPath, "-fleet", "127.0.0.1:9999", "-dbpath", dbPath1, "publish", "-public", "8081:80")
+	cmd1 := exec.Command(binPath, "-dbpath", dbPath1, "publish", "-public", "8081:80")
 	if err := cmd1.Start(); err != nil {
 		t.Fatalf("failed to start diode 1: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestParallelDiodeClients(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Start second diode
-	cmd2 := exec.Command(binPath, "-fleet", "127.0.0.1:9999", "-dbpath", dbPath2, "publish", "-public", "8082:80")
+	cmd2 := exec.Command(binPath, "-dbpath", dbPath2, "publish", "-public", "8082:80")
 	var stdout2 bytes.Buffer
 	cmd2.Stdout = &stdout2
 	cmd2.Stderr = &stdout2


### PR DESCRIPTION
This PR re-supports -fleet in the global flags.  It was removed for some reason in 2020 in favor of a config set approach, but I looked in the code base and a TON of stuff can be set both on flags / commands and in config set.  Also, join supports ephemeral fleet overrides.  This is useful for app-controlled CLIs where implementing a config set would require a separate diode client control path, not to mentioned this is just basically aligned with the rest of the way everything works.