### PR TITLE
Fully enable SSH while retaining ephemeral port usage

### DIFF
--- a/cmd/diode/control_shared.go
+++ b/cmd/diode/control_shared.go
@@ -1867,6 +1867,9 @@ func (dio *Diode) reconcileControlServicesLocked() error {
 	desiredSocksSig := socksServerSignature(cfg)
 	socksRecreated := false
 	if dio.socksServer == nil || dio.controlRuntime.socksSignature != desiredSocksSig {
+		// Shared app SOCKS (socksd/gateway/binds). Ephemeral SSH/scp listeners are a
+		// separate rpc.Server in startSSHLocalSocksProxy; do not route SSH through
+		// dio.socksServer or EnableSocksServer here (avoids fixed-port 1080 conflicts).
 		socksCfg := rpc.Config{
 			EnableSocks: cfg.EnableSocksServer,
 			Addr:        cfg.SocksServerAddr(),

--- a/cmd/diode/control_shared_test.go
+++ b/cmd/diode/control_shared_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/diodechain/diode_client/config"
 	"github.com/diodechain/diode_client/db"
+	"github.com/diodechain/diode_client/rpc"
 	"gopkg.in/yaml.v2"
 )
 
@@ -137,6 +138,62 @@ func TestApplyFleetCLIOverride(t *testing.T) {
 	}
 	if err := applyFleetCLIOverride(fs2, cfg); err == nil {
 		t.Fatal("expected error for empty -fleet")
+	}
+}
+
+// sharedSocksConfig mirrors reconcileControlServicesLocked dio.socksServer wiring.
+func sharedSocksConfig(cfg *config.Config) rpc.Config {
+	return rpc.Config{
+		EnableSocks: cfg.EnableSocksServer,
+		Addr:        cfg.SocksServerAddr(),
+		FleetAddr:   cfg.FleetAddr,
+		Blocklists:  cfg.Blocklists(),
+		Allowlists:  cfg.Allowlists,
+		Fallback:    cfg.SocksFallback,
+	}
+}
+
+func TestSharedSocksReconcileConfigGatesListeners(t *testing.T) {
+	cfg := newSharedControlTestConfig(t)
+	setupSharedControlTestEnv(t, cfg)
+	cm := rpc.NewClientManager(cfg)
+
+	disabled := sharedSocksConfig(cfg)
+	disabled.EnableSocks = cfg.EnableSocksServer
+	server, err := rpc.NewSocksServer(disabled, cm)
+	if err != nil {
+		t.Fatalf("NewSocksServer disabled: %v", err)
+	}
+	defer server.Close()
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start disabled: %v", err)
+	}
+	if server.Addr() != nil {
+		t.Fatal("publish-style config must not bind shared SOCKS when EnableSocksServer is false")
+	}
+
+	if _, err := applySharedControlValue(cfg, "socksd", true); err != nil {
+		t.Fatalf("apply socksd: %v", err)
+	}
+	enabled := sharedSocksConfig(cfg)
+	server2, err := rpc.NewSocksServer(enabled, cm)
+	if err != nil {
+		t.Fatalf("NewSocksServer enabled: %v", err)
+	}
+	defer server2.Close()
+	if err := server2.Start(); err != nil {
+		t.Fatalf("Start enabled: %v", err)
+	}
+	addr := server2.Addr()
+	if addr == nil {
+		t.Fatal("expected listener when EnableSocksServer is true")
+	}
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("addr type %T", addr)
+	}
+	if tcpAddr.Port != defaultSocksServerPort {
+		t.Fatalf("socksd port = %d, want default %d", tcpAddr.Port, defaultSocksServerPort)
 	}
 }
 

--- a/cmd/diode/socks_integration_test.go
+++ b/cmd/diode/socks_integration_test.go
@@ -18,6 +18,8 @@ func buildTestDiode(t *testing.T) string {
 	return binPath
 }
 
+// TestSocksDefaultPortFree regression for #292: publish without -socksd must not bind
+// the default shared SOCKS port (1080), so multiple CLI instances can coexist.
 func TestSocksDefaultPortFree(t *testing.T) {
 	binPath := buildTestDiode(t)
 

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -198,9 +198,14 @@ func subcommandPassThroughArgs(args []string, name string) ([]string, error) {
 	return nil, fmt.Errorf("%s command not found", name)
 }
 
+// startSSHLocalSocksProxy runs a private SOCKS listener for OpenSSH ProxyCommand.
+// It is separate from dio.socksServer / -socksd: Addr uses port 0 so the OS picks an
+// ephemeral port and does not compete with 127.0.0.1:1080. EnableSocks must be true
+// on this instance (rpc.Config); that is not the same as cfg.EnableSocksServer.
 func startSSHLocalSocksProxy() (string, func(), error) {
 	cfg := config.AppConfig
 	socksCfg := rpc.Config{
+		EnableSocks:     true,
 		Addr:            net.JoinHostPort("127.0.0.1", "0"),
 		FleetAddr:       cfg.FleetAddr,
 		Blocklists:      cfg.Blocklists(),

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -16,6 +16,16 @@ import (
 
 // Regression: SSH must listen on an ephemeral port, not shared 127.0.0.1:1080 (see rpc/socks.go).
 func TestStartSSHLocalSocksProxyStartsListener(t *testing.T) {
+	origCfg := config.AppConfig
+	origApp := app
+	t.Cleanup(func() {
+		if app != nil && app != origApp {
+			app.Close()
+		}
+		app = origApp
+		config.AppConfig = origCfg
+	})
+
 	cfg := &config.Config{LogMode: config.LogToConsole, FleetAddr: config.DefaultFleetAddr}
 	logger, err := config.NewLogger(cfg)
 	if err != nil {

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -5,9 +5,51 @@ package main
 
 import (
 	"errors"
+	"net"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/diodechain/diode_client/config"
+	"github.com/diodechain/diode_client/rpc"
 )
+
+// Regression: SSH must listen on an ephemeral port, not shared 127.0.0.1:1080 (see rpc/socks.go).
+func TestStartSSHLocalSocksProxyStartsListener(t *testing.T) {
+	cfg := &config.Config{LogMode: config.LogToConsole, FleetAddr: config.DefaultFleetAddr}
+	logger, err := config.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	cfg.Logger = &logger
+	config.AppConfig = cfg
+	app = NewDiode(cfg)
+	app.clientManager = rpc.NewClientManager(cfg)
+
+	addr, cleanup, err := startSSHLocalSocksProxy()
+	if err != nil {
+		t.Fatalf("startSSHLocalSocksProxy: %v", err)
+	}
+	defer cleanup()
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	conn, err := net.Dial("tcp", net.JoinHostPort(host, portStr))
+	if err != nil {
+		t.Fatalf("dial local socks %q: %v", addr, err)
+	}
+	conn.Close()
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port %q: %v", portStr, err)
+	}
+	if port == 1080 {
+		t.Fatal("SSH local SOCKS must not use default shared socksd port 1080")
+	}
+}
 
 func TestExtractSSHTarget(t *testing.T) {
 	tests := []struct {

--- a/config/flag.go
+++ b/config/flag.go
@@ -82,6 +82,8 @@ type Config struct {
 	EnableAPIServer         bool             `yaml:"api,omitempty" json:"api,omitempty"`
 	EnableProxyServer       bool             `yaml:"gateway,omitempty" json:"gateway,omitempty"`
 	EnableSProxyServer      bool             `yaml:"secure,omitempty" json:"secure,omitempty"`
+	// EnableSocksServer: shared local SOCKS on SocksServerAddr() (default 127.0.0.1:1080).
+	// Unrelated to per-instance rpc.Config.EnableSocks used by diode ssh (ephemeral port).
 	EnableSocksServer       bool             `yaml:"socksd,omitempty" json:"socksd,omitempty"`
 	SocksServerHost         string           `yaml:"socksd_host,omitempty" json:"socksd_host,omitempty"`
 	SocksServerPort         int              `yaml:"socksd_port,omitempty" json:"socksd_port,omitempty"`

--- a/rpc/socks.go
+++ b/rpc/socks.go
@@ -50,10 +50,22 @@ const (
 	stackBufferSize            = 2048
 )
 
-// Config is Socks Server configuration
+// Config is SOCKS server configuration for one rpc.Server instance.
+//
+// EnableSocks vs config.EnableSocksServer (CLI -socksd / DB socksd):
+//   - EnableSocksServer: operator wants the app-wide shared SOCKS proxy on
+//     cfg.SocksServerAddr() (default 127.0.0.1:1080). Reconcile sets
+//     EnableSocks = EnableSocksServer on dio.socksServer.
+//   - EnableSocks: this instance must bind local TCP/UDP listeners on Addr.
+//     Independent of other Server instances. SSH uses a separate Server with
+//     EnableSocks true and Addr 127.0.0.1:0 (ephemeral port); it must not reuse
+//     dio.socksServer or flip EnableSocksServer.
+//
+// Dial/connectDevice works without listeners when EnableSocks is false.
 type Config struct {
-	EnableSocks     bool
-	Addr            string
+	// EnableSocks starts TCP/UDP listeners on Addr for this instance only.
+	EnableSocks bool
+	Addr        string
 	ProxyServerAddr string
 	Fallback        string
 	EnableProxy     bool
@@ -887,7 +899,9 @@ func (socksServer *Server) stopSocksListeners() {
 	}
 }
 
-// Start socks server
+// Start ensures local SOCKS listeners are running when Config.EnableSocks is set.
+// Shared socksd uses reconcile + EnableSocksServer; one-off SSH uses a private
+// Server with EnableSocks true and Addr 127.0.0.1:0 (see cmd/diode/ssh.go).
 func (socksServer *Server) Start() error {
 	if socksServer.Closed() {
 		return nil

--- a/rpc/socks_test.go
+++ b/rpc/socks_test.go
@@ -1,6 +1,8 @@
 package rpc
 
 import (
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -94,4 +96,75 @@ func TestSocksServerDynamicToggle(t *testing.T) {
 	}
 
 	server.Close()
+}
+
+// TestSocksServerSharedListenerBindsAddr guards #292: EnableSocksServer must map to
+// listeners on SocksServerAddr (default 1080), not unconditional bind on every Server.
+func TestSocksServerSharedListenerBindsAddr(t *testing.T) {
+	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
+	logger, _ := config.NewLogger(config.AppConfig)
+	config.AppConfig.Logger = &logger
+	cm := NewClientManager(config.AppConfig)
+
+	const wantPort = 19080
+	cfg := Config{
+		EnableSocks: true,
+		Addr:        net.JoinHostPort("127.0.0.1", strconv.Itoa(wantPort)),
+	}
+
+	server, err := NewSocksServer(cfg, cm)
+	if err != nil {
+		t.Fatalf("NewSocksServer: %v", err)
+	}
+	defer server.Close()
+
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	addr := server.Addr()
+	if addr == nil {
+		t.Fatal("expected listener address")
+	}
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("addr type %T", addr)
+	}
+	if tcpAddr.Port != wantPort {
+		t.Fatalf("port = %d, want %d", tcpAddr.Port, wantPort)
+	}
+	if _, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(wantPort))); err != nil {
+		t.Fatalf("dial shared socks: %v", err)
+	}
+}
+
+// TestSocksServerEphemeralBindUsesNonDefaultPort mirrors diode ssh (127.0.0.1:0).
+func TestSocksServerEphemeralBindUsesNonDefaultPort(t *testing.T) {
+	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
+	logger, _ := config.NewLogger(config.AppConfig)
+	config.AppConfig.Logger = &logger
+	cm := NewClientManager(config.AppConfig)
+
+	cfg := Config{
+		EnableSocks: true,
+		Addr:        "127.0.0.1:0",
+	}
+	server, err := NewSocksServer(cfg, cm)
+	if err != nil {
+		t.Fatalf("NewSocksServer: %v", err)
+	}
+	defer server.Close()
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	addr := server.Addr()
+	if addr == nil {
+		t.Fatal("expected listener address")
+	}
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("addr type %T", addr)
+	}
+	if tcpAddr.Port == 1080 {
+		t.Fatalf("ephemeral bind must not use default socksd port 1080")
+	}
 }

--- a/rpc/socks_test.go
+++ b/rpc/socks_test.go
@@ -9,17 +9,29 @@ import (
 	"github.com/diodechain/diode_client/config"
 )
 
+func setupSocksTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	origCfg := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = origCfg })
+	cfg := &config.Config{LogMode: config.LogToConsole}
+	logger, err := config.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	cfg.Logger = &logger
+	config.AppConfig = cfg
+	return cfg
+}
+
 func TestSocksServerUDPConnClose(t *testing.T) {
-	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
-	logger, _ := config.NewLogger(config.AppConfig)
-	config.AppConfig.Logger = &logger
-	cm := NewClientManager(config.AppConfig)
-	cfg := Config{
+	appCfg := setupSocksTestConfig(t)
+	cm := NewClientManager(appCfg)
+	socksCfg := Config{
 		EnableSocks: true,
 		Addr:        "127.0.0.1:0", // random port
 	}
 
-	server, err := NewSocksServer(cfg, cm)
+	server, err := NewSocksServer(socksCfg, cm)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -48,18 +60,16 @@ func TestSocksServerUDPConnClose(t *testing.T) {
 }
 
 func TestSocksServerDynamicToggle(t *testing.T) {
-	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
-	logger, _ := config.NewLogger(config.AppConfig)
-	config.AppConfig.Logger = &logger
-	cm := NewClientManager(config.AppConfig)
+	appCfg := setupSocksTestConfig(t)
+	cm := NewClientManager(appCfg)
 
 	// Start with socks disabled
-	cfg := Config{
+	socksCfg := Config{
 		EnableSocks: false,
 		Addr:        "127.0.0.1:0", // random port
 	}
 
-	server, err := NewSocksServer(cfg, cm)
+	server, err := NewSocksServer(socksCfg, cm)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -74,8 +84,8 @@ func TestSocksServerDynamicToggle(t *testing.T) {
 	}
 
 	// Dynamically enable socks
-	cfg.EnableSocks = true
-	err = server.SetConfig(cfg)
+	socksCfg.EnableSocks = true
+	err = server.SetConfig(socksCfg)
 	if err != nil {
 		t.Fatalf("failed to SetConfig: %v", err)
 	}
@@ -85,8 +95,8 @@ func TestSocksServerDynamicToggle(t *testing.T) {
 	}
 
 	// Dynamically disable socks
-	cfg.EnableSocks = false
-	err = server.SetConfig(cfg)
+	socksCfg.EnableSocks = false
+	err = server.SetConfig(socksCfg)
 	if err != nil {
 		t.Fatalf("failed to SetConfig: %v", err)
 	}
@@ -101,18 +111,16 @@ func TestSocksServerDynamicToggle(t *testing.T) {
 // TestSocksServerSharedListenerBindsAddr guards #292: EnableSocksServer must map to
 // listeners on SocksServerAddr (default 1080), not unconditional bind on every Server.
 func TestSocksServerSharedListenerBindsAddr(t *testing.T) {
-	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
-	logger, _ := config.NewLogger(config.AppConfig)
-	config.AppConfig.Logger = &logger
-	cm := NewClientManager(config.AppConfig)
+	appCfg := setupSocksTestConfig(t)
+	cm := NewClientManager(appCfg)
 
 	const wantPort = 19080
-	cfg := Config{
+	socksCfg := Config{
 		EnableSocks: true,
 		Addr:        net.JoinHostPort("127.0.0.1", strconv.Itoa(wantPort)),
 	}
 
-	server, err := NewSocksServer(cfg, cm)
+	server, err := NewSocksServer(socksCfg, cm)
 	if err != nil {
 		t.Fatalf("NewSocksServer: %v", err)
 	}
@@ -139,16 +147,14 @@ func TestSocksServerSharedListenerBindsAddr(t *testing.T) {
 
 // TestSocksServerEphemeralBindUsesNonDefaultPort mirrors diode ssh (127.0.0.1:0).
 func TestSocksServerEphemeralBindUsesNonDefaultPort(t *testing.T) {
-	config.AppConfig = &config.Config{LogMode: config.LogToConsole}
-	logger, _ := config.NewLogger(config.AppConfig)
-	config.AppConfig.Logger = &logger
-	cm := NewClientManager(config.AppConfig)
+	appCfg := setupSocksTestConfig(t)
+	cm := NewClientManager(appCfg)
 
-	cfg := Config{
+	socksCfg := Config{
 		EnableSocks: true,
 		Addr:        "127.0.0.1:0",
 	}
-	server, err := NewSocksServer(cfg, cm)
+	server, err := NewSocksServer(socksCfg, cm)
 	if err != nil {
 		t.Fatalf("NewSocksServer: %v", err)
 	}


### PR DESCRIPTION
This PR fixes SSH while retaining ephemeral port usage for the listener.