### PR TITLE
Improve transfer throughput on connected ports

### DIFF
--- a/cmd/diode/fetch.go
+++ b/cmd/diode/fetch.go
@@ -198,8 +198,11 @@ func fetchHandler() (err error) {
 	}
 
 	if f != nil {
-		io.Copy(f, src)
+		_, copyErr := io.Copy(f, src)
 		f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
 	}
 	return
 }

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -475,11 +475,7 @@ func (client *Client) recvMessageLoop() {
 			return
 		}
 		if msg.Len > 0 {
-			select {
-			case msgBuffer <- msg:
-			default:
-				msgBuffer <- msg
-			}
+			msgBuffer <- msg
 		}
 	}
 }

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -443,9 +443,11 @@ func validateRLPValue(k rlp.Kind, content []byte) error {
 	return nil
 }
 
+const inboundMessageQueueDepth = 256
+
 // recvMessageLoop infinite loop to read message from server
 func (client *Client) recvMessageLoop() {
-	msgBuffer := make(chan edge.Message, 20)
+	msgBuffer := make(chan edge.Message, inboundMessageQueueDepth)
 	defer close(msgBuffer)
 
 	go func() {
@@ -476,7 +478,6 @@ func (client *Client) recvMessageLoop() {
 			select {
 			case msgBuffer <- msg:
 			default:
-				// client.Log().Debug("Read queue full\n" + client.timer.Dump())
 				msgBuffer <- msg
 			}
 		}

--- a/rpc/connectedport.go
+++ b/rpc/connectedport.go
@@ -13,12 +13,15 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/diodechain/diode_client/config"
 	"github.com/diodechain/zap"
 	"github.com/dominicletz/genserver"
 )
+
+const localBufferChunk = 64 * 1024
 
 type ConnectedPort struct {
 	srv *genserver.GenServer
@@ -37,16 +40,19 @@ type ConnectedPort struct {
 	localErr         error
 	host             string
 
-	bufferRunning  bool
 	closeWhenEmpty bool
 	localBuffer    bytes.Buffer
 	bufferLock     sync.Mutex
+	bufferCond     *sync.Cond
+	bufferOnce     sync.Once
+	closedFlag     uint32
 }
 
 // New returns a new connected port
 func NewConnectedPort(requestId int64, ref string, deviceID Address, client *Client, portNumber int) *ConnectedPort {
 	host, _ := client.Host()
 	port := &ConnectedPort{Ref: ref, DeviceID: deviceID, client: client, PortNumber: portNumber, srv: genserver.New("Port"), host: host}
+	port.bufferCond = sync.NewCond(&port.bufferLock)
 	port.Log().Debug("%d: Open port %p", requestId, port)
 	port.srv.Terminate = func() {
 		port.Log().Debug("%d: Close port %p", requestId, port)
@@ -60,53 +66,53 @@ func NewConnectedPort(requestId int64, ref string, deviceID Address, client *Cli
 }
 
 func (port *ConnectedPort) bufferRunner() {
-	readBuffer := make([]byte, 1024)
+	readBuffer := make([]byte, localBufferChunk)
 	conn := port.Conn
 	closeWhenEmpty := 0
 
 	if conn == nil {
-		// conn was closed before started
 		return
 	}
 
 	for port.localErr == nil {
 		port.bufferLock.Lock()
-		r, err := port.localBuffer.Read(readBuffer)
-		// fmt.Printf("port.localBuffer.Read(readBuffer) = %v\n", r)
-		if port.closeWhenEmpty && r == 0 {
-			closeWhenEmpty = closeWhenEmpty + 1
-		}
-		port.bufferLock.Unlock()
-		if r == 0 {
-			// This double wait is an issue but we need it atm --
-			// it means we have some port.SendLocal() in the codebase that is triggered
-			// after a port.Close() call... -- so we just wait 100ms for the last write to come in.
-			if closeWhenEmpty == 1 {
-				// fmt.Printf("stopping with closeWhenEmpty (1)\n")
+		for port.localBuffer.Len() == 0 && port.localErr == nil {
+			if port.closeWhenEmpty {
+				closeWhenEmpty++
+				if closeWhenEmpty >= 2 {
+					port.bufferLock.Unlock()
+					conn.Close()
+					return
+				}
+				port.bufferLock.Unlock()
+				// Trailing SendLocal may still arrive after Close(); grace once.
 				time.Sleep(100 * time.Millisecond)
+				port.bufferLock.Lock()
+				continue
 			}
-			if closeWhenEmpty == 2 {
-				// fmt.Printf("stopping with closeWhenEmpty (2)\n")
-				conn.Close()
-				return
-			}
-			time.Sleep(10 * time.Millisecond)
+			port.bufferCond.Wait()
+		}
+		if port.localErr != nil {
+			port.bufferLock.Unlock()
+			break
+		}
+		if port.localBuffer.Len() == 0 {
+			port.bufferLock.Unlock()
 			continue
 		}
-		if err != nil {
-			fmt.Printf("wait what?\n")
+		r, err := port.localBuffer.Read(readBuffer)
+		port.bufferLock.Unlock()
+		if err != nil && err != io.EOF {
 			port.localErr = err
 			break
 		}
-		// for port.Conn == nil {
-		// 	fmt.Printf("port.Conn == nil but got %v bytes to write\n", r)
-		// 	time.Sleep(10 * time.Millisecond)
-		// }
+		if r == 0 {
+			continue
+		}
 		if port.client == nil {
 			break
 		}
 		n, err := conn.Write(readBuffer[:r])
-
 		if err != nil {
 			port.localErr = err
 			break
@@ -178,6 +184,7 @@ func (port *ConnectedPort) close() {
 	if port.closed() {
 		return
 	}
+	atomic.StoreUint32(&port.closedFlag, 1)
 	if port.remoteErr == nil {
 		port.remoteErr = io.EOF
 	}
@@ -192,14 +199,14 @@ func (port *ConnectedPort) close() {
 	port.client.CastPortClose(port.Ref)
 	port.bufferLock.Lock()
 	port.closeWhenEmpty = true
+	port.bufferCond.Broadcast()
 	port.bufferLock.Unlock()
 	port.Conn = nil
 }
 
 // Closed returns true if this has been closed
 func (port *ConnectedPort) Closed() (closed bool) {
-	port.srv.Call(func() { closed = port.closed() })
-	return
+	return atomic.LoadUint32(&port.closedFlag) != 0
 }
 
 func (port *ConnectedPort) closed() bool {
@@ -208,29 +215,26 @@ func (port *ConnectedPort) closed() bool {
 
 // SendLocal sends the data south-bound to the device
 func (port *ConnectedPort) SendLocal(data []byte) (err error) {
-	port.srv.Call(func() {
-		if port.remoteErr != nil {
-			err = port.remoteErr
-			return
-		}
-		if port.Conn == nil {
-			err = fmt.Errorf("connection not yet open")
-			return
-		}
-		if !port.bufferRunning {
-			go port.bufferRunner()
-			port.bufferRunning = true
-		}
-	})
-	if err != nil {
-		port.Close()
-		return
+	if atomic.LoadUint32(&port.closedFlag) != 0 {
+		return io.EOF
 	}
 
+	port.bufferOnce.Do(func() { go port.bufferRunner() })
+
 	port.bufferLock.Lock()
-	port.localBuffer.Write(data)
+	if port.remoteErr != nil {
+		err = port.remoteErr
+	} else if port.Conn == nil {
+		err = fmt.Errorf("connection not yet open")
+	} else {
+		port.localBuffer.Write(data)
+		port.bufferCond.Signal()
+	}
 	port.bufferLock.Unlock()
-	return
+	if err != nil {
+		port.Close()
+	}
+	return err
 }
 
 // Copy copies data from the local connection to the rpc until end

--- a/rpc/connectedport.go
+++ b/rpc/connectedport.go
@@ -67,9 +67,11 @@ func NewConnectedPort(requestId int64, ref string, deviceID Address, client *Cli
 
 func (port *ConnectedPort) bufferRunner() {
 	readBuffer := make([]byte, localBufferChunk)
-	conn := port.Conn
 	closeWhenEmpty := 0
 
+	port.bufferLock.Lock()
+	conn := port.Conn
+	port.bufferLock.Unlock()
 	if conn == nil {
 		return
 	}
@@ -80,8 +82,11 @@ func (port *ConnectedPort) bufferRunner() {
 			if port.closeWhenEmpty {
 				closeWhenEmpty++
 				if closeWhenEmpty >= 2 {
+					conn = port.Conn
 					port.bufferLock.Unlock()
-					conn.Close()
+					if conn != nil {
+						conn.Close()
+					}
 					return
 				}
 				port.bufferLock.Unlock()
@@ -101,6 +106,7 @@ func (port *ConnectedPort) bufferRunner() {
 			continue
 		}
 		r, err := port.localBuffer.Read(readBuffer)
+		conn = port.Conn
 		port.bufferLock.Unlock()
 		if err != nil && err != io.EOF {
 			port.localErr = err
@@ -109,7 +115,7 @@ func (port *ConnectedPort) bufferRunner() {
 		if r == 0 {
 			continue
 		}
-		if port.client == nil {
+		if port.client == nil || conn == nil {
 			break
 		}
 		n, err := conn.Write(readBuffer[:r])
@@ -200,8 +206,8 @@ func (port *ConnectedPort) close() {
 	port.bufferLock.Lock()
 	port.closeWhenEmpty = true
 	port.bufferCond.Broadcast()
-	port.bufferLock.Unlock()
 	port.Conn = nil
+	port.bufferLock.Unlock()
 }
 
 // Closed returns true if this has been closed
@@ -290,13 +296,18 @@ func (port *ConnectedPort) upgradeTLS(fn func(*E2EServer) error) error {
 		port.Log().Error("Failed to tunnel openssl client: %v", err.Error())
 		return err
 	}
-	e2eServer := port.NewE2EServer(port.Conn, port.DeviceID, port.client.pool)
+	port.bufferLock.Lock()
+	oldConn := port.Conn
+	port.bufferLock.Unlock()
+	e2eServer := port.NewE2EServer(oldConn, port.DeviceID, port.client.pool)
 	err := fn(e2eServer)
 	if err != nil {
 		port.Log().Error("Failed to tunnel openssl client: %v", err.Error())
 		return err
 	}
+	port.bufferLock.Lock()
 	port.Conn = NewE2EConn(e2eServer)
+	port.bufferLock.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Replace `SendLocal` polling with a condition-variable-driven write buffer and a 64KB TCP write chunk size
- Avoid per-write `genserver.Call` overhead on the southbound hot path and use an atomic closed flag for cheap `Closed()` checks
- Increase inbound SSL message queue depth from 20 to 256 to reduce recv-loop blocking under burst traffic
- Propagate `io.Copy` errors in `diode fetch` instead of ignoring them

## Test plan
- [x] `go test -tags patch_runtime ./rpc/...`
- [ ] Manual large `diode fetch` / file transfer smoke test

## Note
Independent of relay failover work in #302.

Made with [Cursor](https://cursor.com)