### PR TITLE
Fix CI data race in host connect retry tests

### DIFF
--- a/rpc/client_manager_retry_test.go
+++ b/rpc/client_manager_retry_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestHostConnectRetryBackoff(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: mutates global config.AppConfig (same pattern as client_manager_getdefault_test.go).
 	prevConfig := config.AppConfig
 	defer func() { config.AppConfig = prevConfig }()
 
@@ -49,8 +48,7 @@ func TestHostConnectRetryBackoff(t *testing.T) {
 }
 
 func TestDoSelectNextHostSkipsBackoff(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: mutates global config.AppConfig (same pattern as client_manager_getdefault_test.go).
 	prevConfig := config.AppConfig
 	defer func() { config.AppConfig = prevConfig }()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Master CI failed on commit `033d081` ("Implement backoff for dead servers") because `go test -race` detected a data race in the new retry tests.

[Failed run](https://github.com/diodechain/diode_client/actions/runs/29433109485): Ubuntu job failed during `make openssl` / `make test`; other platform jobs were cancelled as a result.

## Root cause

`TestHostConnectRetryBackoff` and `TestDoSelectNextHostSkipsBackoff` both call `t.Parallel()` while writing `config.AppConfig`. `NewClientManager` → `NewPool` reads that global, so the two tests race under `-race`.

## Fix

Remove `t.Parallel()` from both tests, matching `client_manager_getdefault_test.go` and AGENTS.md guidance to use `t.Parallel()` only when truly safe.

## Verification

```bash
go test -race -count=5 -run 'TestHostConnectRetryBackoff|TestDoSelectNextHostSkipsBackoff' ./rpc/
```

Passes locally after this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9892839-0130-40ef-a690-025f79438869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9892839-0130-40ef-a690-025f79438869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

