### PR TITLE
Fix SSH session WaitGroup race breaking master CI

### DIFF
--- a/rpc/ssh_service.go
+++ b/rpc/ssh_service.go
@@ -48,6 +48,7 @@ type sshProcessHandle struct {
 	close  func() error
 	// copyWG counts stdout/stderr proxy goroutines; waited before closing the SSH channel
 	// so clients observe full command output (see proxySSHProcessIO / waitForProcess).
+	// All copyWG.Add calls must finish before waitForProcess runs (no concurrent Add/Wait).
 	copyWG sync.WaitGroup
 }
 
@@ -496,7 +497,9 @@ func handleSSHSessionStart(req *ssh.Request, proc *sshProcessHandle, localUser s
 	if err != nil || !handled {
 		return next, err
 	}
-	go proxySSHProcessIO(channel, next)
+	// proxySSHProcessIO must run synchronously so copyWG.Add completes before
+	// waitForProcess can call Wait (concurrent Add/Wait is a data race).
+	proxySSHProcessIO(channel, next)
 	go waitForProcess(next)
 	return next, nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Master CI is still red after #306. The retry-test race is fixed, but the latest [master run](https://github.com/diodechain/diode_client/actions/runs/29513930912) fails on `macos-15-intel` with a different data race in the embedded SSH session path.

## Root cause

In `handleSSHSessionStart`, both `proxySSHProcessIO` and `waitForProcess` were started as goroutines:

- `proxySSHProcessIO` calls `copyWG.Add(1)` for stdout/stderr copy goroutines
- `waitForProcess` calls `copyWG.Wait()` after the process exits

`sync.WaitGroup` forbids concurrent `Add` and `Wait`, which `-race` catches. The race also closed the SSH channel before output was fully copied, causing `TestEmbeddedSSHServiceExecCurrentUser` to see empty output.

## Fix

Run `proxySSHProcessIO` synchronously so all `copyWG.Add` calls complete before `waitForProcess` is started. Copy I/O still runs in background goroutines.

## CI context

| Commit | Failure |
|--------|---------|
| `033d081` backoff | Ubuntu: race in `client_manager_retry_test.go` (fixed by #306) |
| `d8c9d09` #306 merge | macOS-15-intel: race in `ssh_service.go` (this PR) |

Ubuntu/macOS-14/ARM already passed on the latest master run; Windows was cancelled due to fail-fast.

## Verification

```bash
go test -tags patch_runtime -race -count=50 -run 'TestEmbeddedSSHServiceExecCurrentUser$' ./rpc/
go test -tags patch_runtime -race -count=5 -run 'TestEmbeddedSSH' ./rpc/
go test -tags patch_runtime -race -count=3 ./rpc/
```

All passed locally after this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9892839-0130-40ef-a690-025f79438869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9892839-0130-40ef-a690-025f79438869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

