### PR TITLE
Default diode ssh/scp logs off the interactive TTY

### DIFF
--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -32,8 +32,6 @@ var (
 	diodeCmd = command.Command{
 		Name:     "diode",
 		HelpText: " Diode network command line interface",
-		PreRun:   prepareDiode,
-		PostRun:  cleanDiode,
 	}
 	bootDiodeAddrs = [6]string{
 		"diode://0xceca2f8cf1983b4cf0c1ba51fd382c2bc37aba58@us1.prenet.diode.io:41046",
@@ -46,6 +44,11 @@ var (
 )
 
 func init() {
+	// Assign hooks after diodeCmd exists so prepareDiode can read Flag.Arg without
+	// an package-init cycle (diodeCmd → prepareDiode → diodeCmd).
+	diodeCmd.PreRun = prepareDiode
+	diodeCmd.PostRun = cleanDiode
+
 	cfg := &config.Config{ChainID: config.DefaultChainID}
 	diodeCmd.Flag.StringVar(&cfg.DBPath, "dbpath", util.DefaultDBPath(), "file path to db file")
 	diodeCmd.Flag.IntVar(&cfg.RetryTimes, "retrytimes", 3, "retry times to connect the remote rpc server")
@@ -107,6 +110,12 @@ func prepareDiode() error {
 				cfg.LoadFromFile = true
 			}
 		}
+	}
+
+	// ssh/scp share a TTY with OpenSSH; keep diode operational logs off the console
+	// unless the operator explicitly chose a log file path.
+	if path := maybeDefaultSSHLogPath(diodeCmd.Flag.Arg(0), cfg.LogFilePath); path != "" {
+		cfg.LogFilePath = path
 	}
 
 	if len(cfg.LogFilePath) > 0 {

--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -112,11 +112,9 @@ func prepareDiode() error {
 		}
 	}
 
-	// ssh/scp share a TTY with OpenSSH; keep diode operational logs off the console
-	// unless the operator explicitly chose a log file path.
-	if path := maybeDefaultSSHLogPath(diodeCmd.Flag.Arg(0), cfg.LogFilePath); path != "" {
-		cfg.LogFilePath = path
-	}
+	// For ssh/scp without an explicit log file, defer file logging until after
+	// client initiation lines have printed (see applySSHLogRedirect).
+	sshDeferredLogPath = maybeDefaultSSHLogPath(diodeCmd.Flag.Arg(0), cfg.LogFilePath)
 
 	if len(cfg.LogFilePath) > 0 {
 		cfg.LogMode = config.LogToFile

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -75,12 +75,32 @@ type sshLikeToolOptions struct {
 }
 
 // maybeDefaultSSHLogPath returns util.DefaultSSHLogPath for diode ssh/scp when
-// logFilePath is unset so operational logs stay off the shared OpenSSH TTY.
+// logFilePath is unset so operational logs can be deferred off the OpenSSH TTY.
 func maybeDefaultSSHLogPath(cmd, logFilePath string) string {
 	if logFilePath != "" || (cmd != sshCommandName && cmd != scpCommandName) {
 		return ""
 	}
 	return util.DefaultSSHLogPath()
+}
+
+// sshDeferredLogPath is set in prepareDiode for ssh/scp when using the default
+// log file: stay on console for initiation lines, then applySSHLogRedirect
+// switches logging to the file before OpenSSH takes the TTY.
+var sshDeferredLogPath string
+
+// applySSHLogRedirect moves diode logs from console to the deferred default file
+// after initiation output. No-op when the path is empty (explicit -logfilepath
+// or non-ssh). The redirect notice is printed on the still-active console logger.
+func applySSHLogRedirect(cfg *config.Config) error {
+	path := sshDeferredLogPath
+	if path == "" {
+		return nil
+	}
+	sshDeferredLogPath = ""
+	cfg.PrintInfo(fmt.Sprintf("Redirecting diode log to %s", path))
+	cfg.LogFilePath = path
+	cfg.LogMode = config.LogToFile
+	return config.ReloadLogger(cfg)
 }
 
 // printSSHFatal records a setup failure and, when logs are file-only, also
@@ -162,6 +182,12 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 	toolPath, err := findOpenSSHTool(toolName)
 	if err != nil {
 		printSSHFatal(cfg, fmt.Sprintf("%s not found", toolName), err)
+		os.Exit(1)
+	}
+
+	// Hand the TTY to OpenSSH next; send further diode operational logs to file.
+	if err := applySSHLogRedirect(cfg); err != nil {
+		printSSHFatal(cfg, "Could not redirect diode log", err)
 		os.Exit(1)
 	}
 

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -74,6 +74,36 @@ type sshLikeToolOptions struct {
 	validateLabel string
 }
 
+// isSSHLikeCommand reports whether name is a diode subcommand that bridges
+// OpenSSH over a temporary local client and should keep logs off the TTY.
+func isSSHLikeCommand(name string) bool {
+	return name == sshCommandName || name == scpCommandName
+}
+
+// maybeDefaultSSHLogPath returns util.DefaultSSHLogPath when cmd is ssh/scp
+// and logFilePath is unset; otherwise it returns empty string (no change).
+func maybeDefaultSSHLogPath(cmd, logFilePath string) string {
+	if logFilePath != "" || !isSSHLikeCommand(cmd) {
+		return ""
+	}
+	return util.DefaultSSHLogPath()
+}
+
+// printSSHFatal records a setup failure on the configured logger and, when
+// operational logs are file-only, also mirrors the message to stderr so
+// os.Exit does not leave a silent failure for the operator.
+func printSSHFatal(cfg *config.Config, label string, err error) {
+	cfg.PrintError(label, err)
+	if cfg == nil || (cfg.LogMode&config.LogToFile) == 0 {
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", label, err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s\n", label)
+}
+
 // runSSHLikeTool runs an OpenSSH tool (ssh, scp) over a temporary local
 // SOCKS proxy that bridges into the Diode network, using an ephemeral
 // identity and a ProxyCommand that tunnels via `diode ssh-proxy`.
@@ -86,12 +116,12 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 	cfg.Logger.Warn("%s command is still BETA, parameters may change", opts.commandName)
 
 	if err := app.Start(); err != nil {
-		cfg.PrintError("Could not start local Diode client", err)
+		printSSHFatal(cfg, "Could not start local Diode client", err)
 		os.Exit(1)
 	}
 	proxyAddr, cleanupProxy, err := startSSHLocalSocksProxy()
 	if err != nil {
-		cfg.PrintError("Could not start local Diode SOCKS proxy", err)
+		printSSHFatal(cfg, "Could not start local Diode SOCKS proxy", err)
 		os.Exit(1)
 	}
 	defer cleanupProxy()
@@ -99,7 +129,7 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 
 	diodeExe, err := os.Executable()
 	if err != nil {
-		cfg.PrintError("Could not determine diode executable path", err)
+		printSSHFatal(cfg, "Could not determine diode executable path", err)
 		os.Exit(1)
 	}
 
@@ -113,7 +143,7 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 	}
 	if cmdIndex == -1 {
 		msg := fmt.Sprintf("%s command not found", opts.commandName)
-		cfg.PrintError(msg, errors.New(msg))
+		printSSHFatal(cfg, msg, errors.New(msg))
 		os.Exit(1)
 	}
 	passArgs := normalizeSSHArgs(os_args[cmdIndex+1:])
@@ -124,21 +154,21 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 			if label == "" {
 				label = fmt.Sprintf("Invalid %s argument", opts.commandName)
 			}
-			cfg.PrintError(label, err)
+			printSSHFatal(cfg, label, err)
 			os.Exit(1)
 		}
 	}
 
 	identityFile, cleanup, err := createEphemeralSSHIdentity()
 	if err != nil {
-		cfg.PrintError("Could not create ephemeral ssh identity", err)
+		printSSHFatal(cfg, "Could not create ephemeral ssh identity", err)
 		os.Exit(1)
 	}
 	defer cleanup()
 
 	toolPath, err := findOpenSSHTool(toolName)
 	if err != nil {
-		cfg.PrintError(fmt.Sprintf("%s not found", toolName), err)
+		printSSHFatal(cfg, fmt.Sprintf("%s not found", toolName), err)
 		os.Exit(1)
 	}
 
@@ -154,7 +184,7 @@ func runSSHLikeTool(opts sshLikeToolOptions) error {
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())
 		}
-		cfg.PrintError(fmt.Sprintf("Could not execute %s", toolName), err)
+		printSSHFatal(cfg, fmt.Sprintf("Could not execute %s", toolName), err)
 		os.Exit(1)
 	}
 	return nil

--- a/cmd/diode/ssh.go
+++ b/cmd/diode/ssh.go
@@ -74,27 +74,20 @@ type sshLikeToolOptions struct {
 	validateLabel string
 }
 
-// isSSHLikeCommand reports whether name is a diode subcommand that bridges
-// OpenSSH over a temporary local client and should keep logs off the TTY.
-func isSSHLikeCommand(name string) bool {
-	return name == sshCommandName || name == scpCommandName
-}
-
-// maybeDefaultSSHLogPath returns util.DefaultSSHLogPath when cmd is ssh/scp
-// and logFilePath is unset; otherwise it returns empty string (no change).
+// maybeDefaultSSHLogPath returns util.DefaultSSHLogPath for diode ssh/scp when
+// logFilePath is unset so operational logs stay off the shared OpenSSH TTY.
 func maybeDefaultSSHLogPath(cmd, logFilePath string) string {
-	if logFilePath != "" || !isSSHLikeCommand(cmd) {
+	if logFilePath != "" || (cmd != sshCommandName && cmd != scpCommandName) {
 		return ""
 	}
 	return util.DefaultSSHLogPath()
 }
 
-// printSSHFatal records a setup failure on the configured logger and, when
-// operational logs are file-only, also mirrors the message to stderr so
-// os.Exit does not leave a silent failure for the operator.
+// printSSHFatal records a setup failure and, when logs are file-only, also
+// mirrors to stderr so os.Exit is not silent for the operator.
 func printSSHFatal(cfg *config.Config, label string, err error) {
 	cfg.PrintError(label, err)
-	if cfg == nil || (cfg.LogMode&config.LogToFile) == 0 {
+	if (cfg.LogMode & config.LogToFile) == 0 {
 		return
 	}
 	if err != nil {

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"errors"
 	"net"
-	"path"
 	"strconv"
 	"strings"
 	"testing"
@@ -213,28 +212,8 @@ func TestFindOpenSSHToolWindowsInstallHelp(t *testing.T) {
 	}
 }
 
-func TestIsSSHLikeCommand(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		want bool
-	}{
-		{"ssh", true},
-		{"scp", true},
-		{"ssh-proxy", false},
-		{"socksd", false},
-		{"", false},
-	} {
-		if got := isSSHLikeCommand(tc.name); got != tc.want {
-			t.Fatalf("isSSHLikeCommand(%q) = %v, want %v", tc.name, got, tc.want)
-		}
-	}
-}
-
 func TestMaybeDefaultSSHLogPath(t *testing.T) {
 	wantDefault := util.DefaultSSHLogPath()
-	if !strings.HasSuffix(wantDefault, path.Join("diode", "ssh.log")) {
-		t.Fatalf("util.DefaultSSHLogPath() = %q, unexpected shape", wantDefault)
-	}
 
 	if got := maybeDefaultSSHLogPath("ssh", ""); got != wantDefault {
 		t.Fatalf("maybeDefaultSSHLogPath(ssh, \"\") = %q, want %q", got, wantDefault)
@@ -247,5 +226,8 @@ func TestMaybeDefaultSSHLogPath(t *testing.T) {
 	}
 	if got := maybeDefaultSSHLogPath("socksd", ""); got != "" {
 		t.Fatalf("maybeDefaultSSHLogPath(socksd, \"\") = %q, want empty", got)
+	}
+	if got := maybeDefaultSSHLogPath("ssh-proxy", ""); got != "" {
+		t.Fatalf("maybeDefaultSSHLogPath(ssh-proxy, \"\") = %q, want empty", got)
 	}
 }

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -229,5 +231,69 @@ func TestMaybeDefaultSSHLogPath(t *testing.T) {
 	}
 	if got := maybeDefaultSSHLogPath("ssh-proxy", ""); got != "" {
 		t.Fatalf("maybeDefaultSSHLogPath(ssh-proxy, \"\") = %q, want empty", got)
+	}
+}
+
+func TestApplySSHLogRedirect(t *testing.T) {
+	origCfg := config.AppConfig
+	origDeferred := sshDeferredLogPath
+	t.Cleanup(func() {
+		if config.AppConfig != nil && config.AppConfig.Logger != nil {
+			_ = config.AppConfig.Logger.Close()
+		}
+		config.AppConfig = origCfg
+		sshDeferredLogPath = origDeferred
+	})
+
+	// No pending path: leave console mode alone.
+	sshDeferredLogPath = ""
+	cfg := &config.Config{LogMode: config.LogToConsole}
+	logger, err := config.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	cfg.Logger = &logger
+	config.AppConfig = cfg
+	if err := applySSHLogRedirect(cfg); err != nil {
+		t.Fatalf("applySSHLogRedirect empty: %v", err)
+	}
+	if cfg.LogMode != config.LogToConsole || cfg.LogFilePath != "" {
+		t.Fatalf("empty defer should not change log mode; mode=%d path=%q", cfg.LogMode, cfg.LogFilePath)
+	}
+
+	// Deferred path: print notice (logged), switch to file, clear deferred slot.
+	logPath := filepath.Join(t.TempDir(), "ssh.log")
+	sshDeferredLogPath = logPath
+	cfg2 := &config.Config{LogMode: config.LogToConsole}
+	logger2, err := config.NewLogger(cfg2)
+	if err != nil {
+		t.Fatalf("NewLogger2: %v", err)
+	}
+	cfg2.Logger = &logger2
+	config.AppConfig = cfg2
+	if err := applySSHLogRedirect(cfg2); err != nil {
+		t.Fatalf("applySSHLogRedirect: %v", err)
+	}
+	t.Cleanup(func() { _ = cfg2.Logger.Close() })
+	if sshDeferredLogPath != "" {
+		t.Fatalf("deferred path should be cleared, got %q", sshDeferredLogPath)
+	}
+	if cfg2.LogMode != config.LogToFile || cfg2.LogFilePath != logPath {
+		t.Fatalf("want file mode at %q, got mode=%d path=%q", logPath, cfg2.LogMode, cfg2.LogFilePath)
+	}
+	// Second call is no-op.
+	if err := applySSHLogRedirect(cfg2); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	cfg2.Logger.Info("after-redirect")
+	if err := cfg2.Logger.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "after-redirect") {
+		t.Fatalf("expected log file contents, got %q", data)
 	}
 }

--- a/cmd/diode/ssh_test.go
+++ b/cmd/diode/ssh_test.go
@@ -6,12 +6,14 @@ package main
 import (
 	"errors"
 	"net"
+	"path"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/diodechain/diode_client/config"
 	"github.com/diodechain/diode_client/rpc"
+	"github.com/diodechain/diode_client/util"
 )
 
 // Regression: SSH must listen on an ephemeral port, not shared 127.0.0.1:1080 (see rpc/socks.go).
@@ -208,5 +210,42 @@ func TestFindOpenSSHToolWindowsInstallHelp(t *testing.T) {
 				t.Fatalf("expected %q in error %q", part, err.Error())
 			}
 		}
+	}
+}
+
+func TestIsSSHLikeCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"ssh", true},
+		{"scp", true},
+		{"ssh-proxy", false},
+		{"socksd", false},
+		{"", false},
+	} {
+		if got := isSSHLikeCommand(tc.name); got != tc.want {
+			t.Fatalf("isSSHLikeCommand(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMaybeDefaultSSHLogPath(t *testing.T) {
+	wantDefault := util.DefaultSSHLogPath()
+	if !strings.HasSuffix(wantDefault, path.Join("diode", "ssh.log")) {
+		t.Fatalf("util.DefaultSSHLogPath() = %q, unexpected shape", wantDefault)
+	}
+
+	if got := maybeDefaultSSHLogPath("ssh", ""); got != wantDefault {
+		t.Fatalf("maybeDefaultSSHLogPath(ssh, \"\") = %q, want %q", got, wantDefault)
+	}
+	if got := maybeDefaultSSHLogPath("scp", ""); got != wantDefault {
+		t.Fatalf("maybeDefaultSSHLogPath(scp, \"\") = %q, want %q", got, wantDefault)
+	}
+	if got := maybeDefaultSSHLogPath("ssh", "/explicit/path.log"); got != "" {
+		t.Fatalf("maybeDefaultSSHLogPath with explicit path = %q, want empty", got)
+	}
+	if got := maybeDefaultSSHLogPath("socksd", ""); got != "" {
+		t.Fatalf("maybeDefaultSSHLogPath(socksd, \"\") = %q, want empty", got)
 	}
 }

--- a/config/logger.go
+++ b/config/logger.go
@@ -20,6 +20,9 @@ const (
 // Logger represent log service for client
 type Logger struct {
 	logger *zap.Logger
+	// file is set when logging to a local path; retained so Close can release
+	// the handle (needed on Windows so temp dirs can delete the log file).
+	file *os.File
 }
 
 func logToFileReady(cfg *Config) bool {
@@ -61,17 +64,17 @@ func loggerEncoderConfig(cfg *Config) zapcore.EncoderConfig {
 	return zapCfg.EncoderConfig
 }
 
-func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
+func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, file *os.File, err error) {
 	level := loggerLevel(cfg)
 	encCfg := loggerEncoderConfig(cfg)
 
 	if logToFileReady(cfg) {
-		f, err := openLogFile(cfg.LogFilePath)
+		file, err = openLogFile(cfg.LogFilePath)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		core := zapcore.NewCore(zapcore.NewConsoleEncoder(encCfg), zapcore.AddSync(f), level)
-		return zap.New(core), nil
+		core := zapcore.NewCore(zapcore.NewConsoleEncoder(encCfg), zapcore.AddSync(file), level)
+		return zap.New(core), file, nil
 	}
 
 	zapCfg := zap.NewProductionConfig()
@@ -80,10 +83,11 @@ func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	zapCfg.DisableStacktrace = true
 	zapCfg.Sampling = nil
 	zapCfg.Encoding = "consoleraw"
-	return zapCfg.Build()
+	logger, err = zapCfg.Build()
+	return logger, nil, err
 }
 
-func newZapLogger(cfg *Config) (logger *zap.Logger, err error) {
+func newZapLogger(cfg *Config) (logger *zap.Logger, file *os.File, err error) {
 	var remote zapcore.WriteSyncer
 	if cfg.LogTargetRemote != nil {
 		if ws, ok := cfg.LogTargetRemote.(zapcore.WriteSyncer); ok {
@@ -95,9 +99,9 @@ func newZapLogger(cfg *Config) (logger *zap.Logger, err error) {
 	}
 
 	// Tee: build primary the same way as legacy, then add a second core for remote.
-	primary, err := newZapLoggerLegacy(cfg)
+	primary, file, err := newZapLoggerLegacy(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Extract the single core from the legacy logger (zap always has at least one).
 	cores := primary.Core()
@@ -105,22 +109,41 @@ func newZapLogger(cfg *Config) (logger *zap.Logger, err error) {
 	level := loggerLevel(cfg)
 	encR := zapcore.NewConsoleEncoder(encCfg)
 	remoteCore := zapcore.NewCore(encR, remote, level)
-	return zap.New(zapcore.NewTee(cores, remoteCore)), nil
+	return zap.New(zapcore.NewTee(cores, remoteCore)), file, nil
 }
 
 // NewLogger initialize logger with given config
 func NewLogger(cfg *Config) (l Logger, err error) {
-	l.logger, err = newZapLogger(cfg)
+	l.logger, l.file, err = newZapLogger(cfg)
 	return
+}
+
+// Close flushes and releases an underlying log file, if any.
+func (l *Logger) Close() error {
+	if l == nil {
+		return nil
+	}
+	if l.logger != nil {
+		_ = l.logger.Sync()
+	}
+	if l.file == nil {
+		return nil
+	}
+	err := l.file.Close()
+	l.file = nil
+	return err
 }
 
 // ReloadLogger replaces cfg.Logger using current cfg (e.g. after LogTargetRemote is set).
 func ReloadLogger(cfg *Config) error {
-	logger, err := newZapLogger(cfg)
+	logger, file, err := newZapLogger(cfg)
 	if err != nil {
 		return err
 	}
-	cfg.Logger = &Logger{logger: logger}
+	if cfg.Logger != nil {
+		_ = cfg.Logger.Close()
+	}
+	cfg.Logger = &Logger{logger: logger, file: file}
 	return nil
 }
 

--- a/config/logger.go
+++ b/config/logger.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +27,25 @@ func logToFileReady(cfg *Config) bool {
 	return (cfg.LogMode&LogToFile) > 0 && cfg.LogFilePath != ""
 }
 
+// zapFilePath formats a filesystem path for zap OutputPaths.
+// Zap treats OutputPaths as URLs; Windows drive letters (C:\...) become
+// schemes like "c" unless rewritten as file:// URLs.
+func zapFilePath(path string) string {
+	if path == "" {
+		return path
+	}
+	// Already a URI (file://, stdout, stderr, …).
+	if strings.Contains(path, "://") {
+		return path
+	}
+	if len(path) > 1 && path[1] == ':' {
+		// Drive-letter absolute path → file:///C:/...
+		slash := filepath.ToSlash(path)
+		return (&url.URL{Scheme: "file", Path: "/" + slash}).String()
+	}
+	return path
+}
+
 func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	zapCfg := zap.NewProductionConfig()
 	if cfg.LogDateTime || cfg.Debug {
@@ -39,8 +59,9 @@ func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 		if err = os.MkdirAll(filepath.Dir(cfg.LogFilePath), 0700); err != nil {
 			return nil, err
 		}
-		zapCfg.OutputPaths = []string{cfg.LogFilePath}
-		zapCfg.ErrorOutputPaths = []string{cfg.LogFilePath}
+		sink := zapFilePath(cfg.LogFilePath)
+		zapCfg.OutputPaths = []string{sink}
+		zapCfg.ErrorOutputPaths = []string{sink}
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	} else {
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder

--- a/config/logger.go
+++ b/config/logger.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/diodechain/zap"
@@ -21,6 +22,18 @@ type Logger struct {
 	logger *zap.Logger
 }
 
+func logToFileReady(cfg *Config) bool {
+	return (cfg.LogMode&LogToFile) > 0 && cfg.LogFilePath != ""
+}
+
+func ensureLogFileParent(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		return nil
+	}
+	return os.MkdirAll(dir, 0700)
+}
+
 func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	zapCfg := zap.NewProductionConfig()
 	if cfg.LogDateTime || cfg.Debug {
@@ -30,15 +43,13 @@ func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	}
 	zapCfg.EncoderConfig.CallerKey = ""
 	zapCfg.DisableStacktrace = true
-	if (cfg.LogMode & LogToFile) > 0 {
-		_, err = os.Stat(cfg.LogFilePath)
-		if err == nil || os.IsExist(err) {
-			zapCfg.OutputPaths = []string{cfg.LogFilePath}
-			zapCfg.ErrorOutputPaths = []string{cfg.LogFilePath}
-			zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-		} else {
-			zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	if logToFileReady(cfg) {
+		if err = ensureLogFileParent(cfg.LogFilePath); err != nil {
+			return nil, err
 		}
+		zapCfg.OutputPaths = []string{cfg.LogFilePath}
+		zapCfg.ErrorOutputPaths = []string{cfg.LogFilePath}
+		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	} else {
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	}
@@ -95,13 +106,8 @@ func buildEncoderConfigForTee(cfg *Config) zapcore.EncoderConfig {
 	}
 	zapCfg.EncoderConfig.CallerKey = ""
 	zapCfg.DisableStacktrace = true
-	if (cfg.LogMode & LogToFile) > 0 {
-		_, err := os.Stat(cfg.LogFilePath)
-		if err == nil || os.IsExist(err) {
-			zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-		} else {
-			zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-		}
+	if logToFileReady(cfg) {
+		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	} else {
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	}

--- a/config/logger.go
+++ b/config/logger.go
@@ -26,14 +26,6 @@ func logToFileReady(cfg *Config) bool {
 	return (cfg.LogMode&LogToFile) > 0 && cfg.LogFilePath != ""
 }
 
-func ensureLogFileParent(path string) error {
-	dir := filepath.Dir(path)
-	if dir == "" || dir == "." {
-		return nil
-	}
-	return os.MkdirAll(dir, 0700)
-}
-
 func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	zapCfg := zap.NewProductionConfig()
 	if cfg.LogDateTime || cfg.Debug {
@@ -44,7 +36,7 @@ func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	zapCfg.EncoderConfig.CallerKey = ""
 	zapCfg.DisableStacktrace = true
 	if logToFileReady(cfg) {
-		if err = ensureLogFileParent(cfg.LogFilePath); err != nil {
+		if err = os.MkdirAll(filepath.Dir(cfg.LogFilePath), 0700); err != nil {
 			return nil, err
 		}
 		zapCfg.OutputPaths = []string{cfg.LogFilePath}

--- a/config/logger.go
+++ b/config/logger.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,41 +26,27 @@ func logToFileReady(cfg *Config) bool {
 	return (cfg.LogMode&LogToFile) > 0 && cfg.LogFilePath != ""
 }
 
-// zapFilePath formats a filesystem path for zap OutputPaths.
-// Zap treats OutputPaths as URLs; Windows drive letters (C:\...) become
-// schemes like "c" unless rewritten as file:// URLs.
-func zapFilePath(path string) string {
-	if path == "" {
-		return path
+func openLogFile(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, err
 	}
-	// Already a URI (file://, stdout, stderr, …).
-	if strings.Contains(path, "://") {
-		return path
-	}
-	if len(path) > 1 && path[1] == ':' {
-		// Drive-letter absolute path → file:///C:/...
-		slash := filepath.ToSlash(path)
-		return (&url.URL{Scheme: "file", Path: "/" + slash}).String()
-	}
-	return path
+	// Open the path with os.OpenFile rather than zap OutputPaths: zap parses
+	// OutputPaths as URLs, so Windows drive letters (C:\...) break as schemes.
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 }
 
-func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
-	zapCfg := zap.NewProductionConfig()
+func loggerLevel(cfg *Config) zap.AtomicLevel {
 	if cfg.LogDateTime || cfg.Debug {
-		zapCfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	} else {
-		zapCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+		return zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
+	return zap.NewAtomicLevelAt(zap.InfoLevel)
+}
+
+func loggerEncoderConfig(cfg *Config) zapcore.EncoderConfig {
+	zapCfg := zap.NewProductionConfig()
 	zapCfg.EncoderConfig.CallerKey = ""
 	zapCfg.DisableStacktrace = true
 	if logToFileReady(cfg) {
-		if err = os.MkdirAll(filepath.Dir(cfg.LogFilePath), 0700); err != nil {
-			return nil, err
-		}
-		sink := zapFilePath(cfg.LogFilePath)
-		zapCfg.OutputPaths = []string{sink}
-		zapCfg.ErrorOutputPaths = []string{sink}
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	} else {
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
@@ -71,10 +56,30 @@ func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
 	} else {
 		zapCfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(termDatetimeTempl)
 	}
-	zapCfg.Sampling = nil
-	zapCfg.Encoding = "consoleraw"
 	zapCfg.EncoderConfig.ConsoleSeparator = " "
 	zapCfg.EncoderConfig.LevelKey = "[L]"
+	return zapCfg.EncoderConfig
+}
+
+func newZapLoggerLegacy(cfg *Config) (logger *zap.Logger, err error) {
+	level := loggerLevel(cfg)
+	encCfg := loggerEncoderConfig(cfg)
+
+	if logToFileReady(cfg) {
+		f, err := openLogFile(cfg.LogFilePath)
+		if err != nil {
+			return nil, err
+		}
+		core := zapcore.NewCore(zapcore.NewConsoleEncoder(encCfg), zapcore.AddSync(f), level)
+		return zap.New(core), nil
+	}
+
+	zapCfg := zap.NewProductionConfig()
+	zapCfg.Level = level
+	zapCfg.EncoderConfig = encCfg
+	zapCfg.DisableStacktrace = true
+	zapCfg.Sampling = nil
+	zapCfg.Encoding = "consoleraw"
 	return zapCfg.Build()
 }
 
@@ -96,42 +101,11 @@ func newZapLogger(cfg *Config) (logger *zap.Logger, err error) {
 	}
 	// Extract the single core from the legacy logger (zap always has at least one).
 	cores := primary.Core()
-	encCfg := buildEncoderConfigForTee(cfg)
-	level := levelEnablerForTee(cfg)
+	encCfg := loggerEncoderConfig(cfg)
+	level := loggerLevel(cfg)
 	encR := zapcore.NewConsoleEncoder(encCfg)
 	remoteCore := zapcore.NewCore(encR, remote, level)
 	return zap.New(zapcore.NewTee(cores, remoteCore)), nil
-}
-
-func levelEnablerForTee(cfg *Config) zapcore.LevelEnabler {
-	if cfg.LogDateTime || cfg.Debug {
-		return zap.NewAtomicLevelAt(zap.DebugLevel)
-	}
-	return zap.NewAtomicLevelAt(zap.InfoLevel)
-}
-
-func buildEncoderConfigForTee(cfg *Config) zapcore.EncoderConfig {
-	zapCfg := zap.NewProductionConfig()
-	if cfg.LogDateTime || cfg.Debug {
-		zapCfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	} else {
-		zapCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	}
-	zapCfg.EncoderConfig.CallerKey = ""
-	zapCfg.DisableStacktrace = true
-	if logToFileReady(cfg) {
-		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-	} else {
-		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	}
-	if !cfg.LogDateTime {
-		zapCfg.EncoderConfig.TimeKey = ""
-	} else {
-		zapCfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(termDatetimeTempl)
-	}
-	zapCfg.EncoderConfig.ConsoleSeparator = " "
-	zapCfg.EncoderConfig.LevelKey = "[L]"
-	return zapCfg.EncoderConfig
 }
 
 // NewLogger initialize logger with given config

--- a/config/logger_test.go
+++ b/config/logger_test.go
@@ -7,31 +7,9 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
-
-func TestZapFilePathWindowsDrive(t *testing.T) {
-	got := zapFilePath(`D:\a\_temp\client.log`)
-	if !strings.HasPrefix(got, "file:///") {
-		t.Fatalf("zapFilePath(drive) = %q, want file:/// prefix", got)
-	}
-	if !strings.Contains(strings.ToUpper(got), "D:") {
-		t.Fatalf("zapFilePath(drive) = %q, want drive letter in path", got)
-	}
-	// Must not leave bare D: as a URL scheme.
-	if strings.HasPrefix(got, "D:") || strings.HasPrefix(got, "d:") {
-		t.Fatalf("zapFilePath left bare drive path: %q", got)
-	}
-}
-
-func TestZapFilePathUnixUnchanged(t *testing.T) {
-	got := zapFilePath("/tmp/diode/ssh.log")
-	if got != "/tmp/diode/ssh.log" {
-		t.Fatalf("zapFilePath(unix) = %q, want unchanged", got)
-	}
-}
 
 func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 	dir := t.TempDir()
@@ -64,26 +42,20 @@ func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 	}
 }
 
-func TestNewLoggerAcceptsWindowsStylePath(t *testing.T) {
-	// Regression for zap parsing drive letters as URI schemes.
-	if runtime.GOOS != "windows" {
-		sink := zapFilePath(`C:\Users\test\diode\ssh.log`)
-		if !strings.HasPrefix(sink, "file:///") {
-			t.Fatalf("expected file URL on drive path, got %q", sink)
-		}
-		return
-	}
+func TestNewLoggerAcceptsDrivePath(t *testing.T) {
+	// Absolute TempDir paths use drive letters on Windows; openLogFile must not
+	// route them through zap OutputPaths URL parsing.
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "ssh.log")
 	cfg := &Config{LogMode: LogToFile, LogFilePath: logPath}
 	logger, err := NewLogger(cfg)
 	if err != nil {
-		t.Fatalf("NewLogger on Windows path: %v", err)
+		t.Fatalf("NewLogger on absolute path %q: %v", logPath, err)
 	}
 	cfg.Logger = &logger
-	cfg.Logger.Info("windows-log-ok")
+	cfg.Logger.Info("drive-path-ok")
 	_ = cfg.Logger.logger.Sync()
 	if _, err := os.Stat(logPath); err != nil {
-		t.Fatalf("log not created: %v", err)
+		t.Fatalf("log not created at %q: %v", logPath, err)
 	}
 }

--- a/config/logger_test.go
+++ b/config/logger_test.go
@@ -28,6 +28,7 @@ func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 		t.Fatalf("NewLogger(): %v", err)
 	}
 	cfg.Logger = &logger
+	t.Cleanup(func() { _ = cfg.Logger.Close() })
 
 	marker := "logger-file-create-test-marker"
 	cfg.Logger.Info("%s", marker)
@@ -39,6 +40,10 @@ func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 	}
 	if !strings.Contains(string(data), marker) {
 		t.Fatalf("log file missing marker %q; contents=%q", marker, data)
+	}
+	// Close before TempDir cleanup (Windows cannot delete open files).
+	if err := cfg.Logger.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
 	}
 }
 
@@ -53,9 +58,13 @@ func TestNewLoggerAcceptsDrivePath(t *testing.T) {
 		t.Fatalf("NewLogger on absolute path %q: %v", logPath, err)
 	}
 	cfg.Logger = &logger
+	t.Cleanup(func() { _ = cfg.Logger.Close() })
 	cfg.Logger.Info("drive-path-ok")
 	_ = cfg.Logger.logger.Sync()
 	if _, err := os.Stat(logPath); err != nil {
 		t.Fatalf("log not created at %q: %v", logPath, err)
+	}
+	if err := cfg.Logger.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
 	}
 }

--- a/config/logger_test.go
+++ b/config/logger_test.go
@@ -1,0 +1,43 @@
+// Diode Network Client
+// Copyright 2026 Diode
+// Licensed under the Diode License, Version 1.1
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
+	dir := t.TempDir()
+	// Nested path that does not exist yet — logger must MkdirAll + open.
+	logPath := filepath.Join(dir, "nested", "client.log")
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: log path should not exist, stat err=%v", err)
+	}
+
+	cfg := &Config{
+		LogMode:     LogToFile,
+		LogFilePath: logPath,
+	}
+	logger, err := NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewLogger(): %v", err)
+	}
+	cfg.Logger = &logger
+
+	marker := "logger-file-create-test-marker"
+	cfg.Logger.Info("%s", marker)
+	_ = cfg.Logger.logger.Sync()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", logPath, err)
+	}
+	if !strings.Contains(string(data), marker) {
+		t.Fatalf("log file missing marker %q; contents=%q", marker, data)
+	}
+}

--- a/config/logger_test.go
+++ b/config/logger_test.go
@@ -7,9 +7,31 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestZapFilePathWindowsDrive(t *testing.T) {
+	got := zapFilePath(`D:\a\_temp\client.log`)
+	if !strings.HasPrefix(got, "file:///") {
+		t.Fatalf("zapFilePath(drive) = %q, want file:/// prefix", got)
+	}
+	if !strings.Contains(strings.ToUpper(got), "D:") {
+		t.Fatalf("zapFilePath(drive) = %q, want drive letter in path", got)
+	}
+	// Must not leave bare D: as a URL scheme.
+	if strings.HasPrefix(got, "D:") || strings.HasPrefix(got, "d:") {
+		t.Fatalf("zapFilePath left bare drive path: %q", got)
+	}
+}
+
+func TestZapFilePathUnixUnchanged(t *testing.T) {
+	got := zapFilePath("/tmp/diode/ssh.log")
+	if got != "/tmp/diode/ssh.log" {
+		t.Fatalf("zapFilePath(unix) = %q, want unchanged", got)
+	}
+}
 
 func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 	dir := t.TempDir()
@@ -39,5 +61,29 @@ func TestNewLoggerCreatesMissingLogFile(t *testing.T) {
 	}
 	if !strings.Contains(string(data), marker) {
 		t.Fatalf("log file missing marker %q; contents=%q", marker, data)
+	}
+}
+
+func TestNewLoggerAcceptsWindowsStylePath(t *testing.T) {
+	// Regression for zap parsing drive letters as URI schemes.
+	if runtime.GOOS != "windows" {
+		sink := zapFilePath(`C:\Users\test\diode\ssh.log`)
+		if !strings.HasPrefix(sink, "file:///") {
+			t.Fatalf("expected file URL on drive path, got %q", sink)
+		}
+		return
+	}
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "ssh.log")
+	cfg := &Config{LogMode: LogToFile, LogFilePath: logPath}
+	logger, err := NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewLogger on Windows path: %v", err)
+	}
+	cfg.Logger = &logger
+	cfg.Logger.Info("windows-log-ok")
+	_ = cfg.Logger.logger.Sync()
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("log not created: %v", err)
 	}
 }

--- a/util/defaults.go
+++ b/util/defaults.go
@@ -10,10 +10,19 @@ import (
 
 // DefaultDBPath returns default file path to diode private database
 func DefaultDBPath() string {
+	return path.Join(diodeConfigDir(), "private.db")
+}
+
+// DefaultSSHLogPath returns the default log file path used by diode ssh/scp
+// so operational client logs do not interleave with an interactive TTY session.
+func DefaultSSHLogPath() string {
+	return path.Join(diodeConfigDir(), "ssh.log")
+}
+
+func diodeConfigDir() string {
 	confgDir, err := os.UserConfigDir()
 	if err != nil {
 		confgDir = "."
 	}
-
-	return path.Join(confgDir, "diode", "private.db")
+	return path.Join(confgDir, "diode")
 }

--- a/util/defaults_test.go
+++ b/util/defaults_test.go
@@ -1,0 +1,30 @@
+// Diode Network Client
+// Copyright 2026 Diode
+// Licensed under the Diode License, Version 1.1
+
+package util
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestDefaultSSHLogPath(t *testing.T) {
+	got := DefaultSSHLogPath()
+	wantSuffix := path.Join("diode", "ssh.log")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("DefaultSSHLogPath() = %q, want suffix %q", got, wantSuffix)
+	}
+	if strings.Contains(got, "private.db") {
+		t.Fatalf("DefaultSSHLogPath() unexpectedly shares private.db path: %q", got)
+	}
+}
+
+func TestDefaultDBPathAndSSHLogShareDir(t *testing.T) {
+	db := DefaultDBPath()
+	log := DefaultSSHLogPath()
+	if path.Dir(db) != path.Dir(log) {
+		t.Fatalf("expected same config dir: db=%q log=%q", db, log)
+	}
+}


### PR DESCRIPTION
## Summary
- For `diode ssh` / `diode scp`, default `-logfilepath` to `UserConfigDir/diode/ssh.log` when unset so ClientManager Info/Warn does not interrupt OpenSSH sessions
- Fix file logging to create missing parents/files (no longer requires the log path to already exist)
- Mirror ssh/scp setup fatals to stderr when logs go only to a file so failures are not silent
- Explicit `-logfilepath` still overrides the default

## Test plan
- [x] `go test ./util/ ./config/`
- [x] `go test -tags patch_runtime ./cmd/diode/ -run 'TestMaybeDefaultSSHLogPath|…'`
- [ ] Manual: `diode -update=false ssh user@host.diode` — TTY free of ClientManager WARN/INFO; lines appear in default `ssh.log`
- [ ] Manual: `diode -update=false -logfilepath /tmp/other.log ssh user@host.diode` — override path used
- [ ] Manual: force a setup error with file logging and confirm the message still prints on stderr


Made with [Cursor](https://cursor.com)